### PR TITLE
Improve paper processing notifications and fix polling order

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -76,17 +76,15 @@ def _poll_processing_papers() -> None:
             except Exception:
                 pass
             title = info.get("title", arxiv_id)
-            st.toast(f"✅ 「{title}」 の解析が完了しました", icon="✅")
             del st.session_state.processing_papers[arxiv_id]
+            st.toast(f"解析が完了しました！", icon="✅")
+            st.rerun()
 
         elif status == "failed":
             error_msg = status_data.get("error", "不明なエラー")
             title = info.get("title", arxiv_id)
-            st.toast(f"❌ 「{title}」 の解析に失敗しました: {error_msg}", icon="❌")
             del st.session_state.processing_papers[arxiv_id]
-
-
-_poll_processing_papers()
+            st.error(f"「{title}」 の解析に失敗しました: {error_msg}")
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +165,14 @@ def api_update_extract_result(arxiv_id: str, structure: dict) -> None:
         timeout=30,
     )
     resp.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# Polling: check status of in-flight jobs and fire toasts
+# (called here, after all API helpers are defined)
+# ---------------------------------------------------------------------------
+
+_poll_processing_papers()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Refactored the paper processing notification system to provide better user feedback and fixed a critical ordering issue where the polling function was called before all API helpers were defined.

## Key Changes
- **Simplified toast messages**: Removed paper titles from completion toasts to reduce verbosity while keeping users informed
- **Enhanced error handling**: Changed failed processing notifications from toasts to `st.error()` for better visibility and persistence
- **Added page rerun**: Trigger `st.rerun()` on successful processing completion to immediately reflect changes in the UI
- **Fixed function call order**: Moved `_poll_processing_papers()` call to after all API helper functions are defined, preventing potential undefined reference errors
- **Improved code organization**: Added clear section comments to document the polling logic placement

## Implementation Details
- The polling function now properly executes after `api_update_extract_result()` and other dependencies are available
- Error messages for failed analyses are now displayed using Streamlit's error component instead of toast notifications, making them more prominent and persistent
- Successful completions now trigger a page rerun to ensure the UI reflects the latest state immediately

https://claude.ai/code/session_01241uyZ8tWEd6ShghvRcgcK