### PR TITLE
Add chat history persistence to Neo4j with authentication

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import json
 import logging
 import os
 import threading
@@ -150,6 +151,12 @@ class ChatResponse(BaseModel):
     """Response from the RAG chat endpoint."""
 
     answer: str
+
+
+class ChatHistoryResponse(BaseModel):
+    """Response from the chat history endpoint."""
+
+    history: list[dict]
 
 
 class ProposeStructureRequest(BaseModel):
@@ -447,11 +454,14 @@ def update_extract_result(arxiv_id: str, body: PaperStructure) -> PaperStructure
 
 
 @app.post("/api/chat", response_model=ChatResponse)
-def chat(body: ChatRequest) -> ChatResponse:
-    """RAG-based chat endpoint.
+def chat(
+    body: ChatRequest,
+    current_user: dict = Depends(_get_current_user),
+) -> ChatResponse:
+    """RAG-based chat endpoint (requires authentication).
 
     ユーザーの質問を受け取り、Qdrant のベクトル検索と MinIO の PaperStructure を
-    組み合わせて LLM に回答を生成させる。
+    組み合わせて LLM に回答を生成させる。回答後、チャット履歴を Neo4j に永続化する。
     """
     try:
         answer = generate_chat_response(
@@ -464,7 +474,61 @@ def chat(body: ChatRequest) -> ChatResponse:
         logger.exception("Chat generation failed for %s", body.arxiv_id)
         raise HTTPException(status_code=500, detail=f"Chat failed: {exc}") from exc
 
+    # Persist updated chat history to Neo4j
+    updated_history = body.history + [
+        {"role": "user", "content": body.message},
+        {"role": "assistant", "content": answer},
+    ]
+    try:
+        driver = get_driver()
+        with driver.session() as session:
+            session.run(
+                """
+                MERGE (u:User {id: $user_id})
+                MERGE (p:Paper {arxiv_id: $arxiv_id})
+                MERGE (u)-[r:CHATTED_ABOUT]->(p)
+                SET r.history = $history
+                """,
+                user_id=current_user["id"],
+                arxiv_id=body.arxiv_id,
+                history=json.dumps(updated_history, ensure_ascii=False),
+            )
+    except Exception:
+        logger.exception(
+            "Failed to persist chat history for user=%s arxiv_id=%s",
+            current_user["id"],
+            body.arxiv_id,
+        )
+
     return ChatResponse(answer=answer)
+
+
+@app.get("/api/chat/history/{arxiv_id}", response_model=ChatHistoryResponse)
+def get_chat_history(
+    arxiv_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> ChatHistoryResponse:
+    """ログイン中のユーザーの特定論文に対するチャット履歴を Neo4j から取得して返す。"""
+    driver = get_driver()
+    with driver.session() as session:
+        record = session.run(
+            """
+            MATCH (u:User {id: $user_id})-[r:CHATTED_ABOUT]->(p:Paper {arxiv_id: $arxiv_id})
+            RETURN r.history AS history
+            """,
+            user_id=current_user["id"],
+            arxiv_id=arxiv_id,
+        ).single()
+
+    if not record or not record["history"]:
+        return ChatHistoryResponse(history=[])
+
+    try:
+        history = json.loads(record["history"])
+    except Exception:
+        history = []
+
+    return ChatHistoryResponse(history=history)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -101,10 +101,16 @@ def _poll_processing_papers() -> None:
 # API helpers
 # ---------------------------------------------------------------------------
 
+def _auth_headers() -> dict:
+    """Return Authorization header dict for the current session token."""
+    return {"Authorization": f"Bearer {st.session_state.token}"}
+
+
 def api_search(query: str, max_results: int) -> list[dict]:
     resp = requests.get(
         f"{BACKEND_URL}/api/search",
         params={"query": query, "max_results": max_results},
+        headers=_auth_headers(),
         timeout=60,
     )
     resp.raise_for_status()
@@ -113,7 +119,12 @@ def api_search(query: str, max_results: int) -> list[dict]:
 
 def api_fetch(paper: dict) -> str:
     """POST /api/fetch and return the MinIO object name."""
-    resp = requests.post(f"{BACKEND_URL}/api/fetch", json=paper, timeout=120)
+    resp = requests.post(
+        f"{BACKEND_URL}/api/fetch",
+        json=paper,
+        headers=_auth_headers(),
+        timeout=120,
+    )
     resp.raise_for_status()
     return resp.json()["object_name"]
 
@@ -122,6 +133,7 @@ def api_presigned_url(object_name: str) -> str:
     resp = requests.get(
         f"{BACKEND_URL}/api/presigned-url",
         params={"object_name": object_name},
+        headers=_auth_headers(),
         timeout=15,
     )
     resp.raise_for_status()
@@ -129,7 +141,11 @@ def api_presigned_url(object_name: str) -> str:
 
 
 def api_list_papers() -> list[str]:
-    resp = requests.get(f"{BACKEND_URL}/api/papers", timeout=15)
+    resp = requests.get(
+        f"{BACKEND_URL}/api/papers",
+        headers=_auth_headers(),
+        timeout=15,
+    )
     resp.raise_for_status()
     return resp.json()
 
@@ -139,6 +155,7 @@ def api_extract(object_name: str, arxiv_id: str) -> dict:
     resp = requests.post(
         f"{BACKEND_URL}/api/extract",
         json={"object_name": object_name, "arxiv_id": arxiv_id},
+        headers=_auth_headers(),
         timeout=30,
     )
     resp.raise_for_status()
@@ -149,6 +166,7 @@ def api_extract_status(arxiv_id: str) -> dict:
     """GET /api/extract-status/{arxiv_id} — poll job status."""
     resp = requests.get(
         f"{BACKEND_URL}/api/extract-status/{arxiv_id}",
+        headers=_auth_headers(),
         timeout=10,
     )
     if resp.status_code == 404:
@@ -161,6 +179,7 @@ def api_get_extract_result(arxiv_id: str) -> dict:
     """GET /api/extract-result/{arxiv_id} — load a saved structure from MinIO."""
     resp = requests.get(
         f"{BACKEND_URL}/api/extract-result/{arxiv_id}",
+        headers=_auth_headers(),
         timeout=15,
     )
     resp.raise_for_status()
@@ -172,20 +191,35 @@ def api_update_extract_result(arxiv_id: str, structure: dict) -> None:
     resp = requests.put(
         f"{BACKEND_URL}/api/extract-result/{arxiv_id}",
         json=structure,
+        headers=_auth_headers(),
         timeout=30,
     )
     resp.raise_for_status()
 
 
 def api_chat(arxiv_id: str, message: str, history: list[dict]) -> str:
-    """POST /api/chat — RAG-based chat response."""
+    """POST /api/chat — RAG-based chat response (requires auth)."""
     resp = requests.post(
         f"{BACKEND_URL}/api/chat",
         json={"arxiv_id": arxiv_id, "message": message, "history": history},
+        headers=_auth_headers(),
         timeout=60,
     )
     resp.raise_for_status()
     return resp.json()["answer"]
+
+
+def api_get_chat_history(arxiv_id: str) -> list[dict]:
+    """GET /api/chat/history/{arxiv_id} — load chat history from Neo4j."""
+    resp = requests.get(
+        f"{BACKEND_URL}/api/chat/history/{arxiv_id}",
+        headers=_auth_headers(),
+        timeout=10,
+    )
+    if resp.status_code == 404:
+        return []
+    resp.raise_for_status()
+    return resp.json().get("history", [])
 
 
 def _auth_post(path: str, payload: dict) -> dict:
@@ -716,9 +750,13 @@ elif page == "Validation View":
                         " 回答はQdrantのベクトル検索と抽出済み構造データを参照して生成されます。"
                     )
 
-                    # 論文ごとのチャット履歴を初期化
+                    # 論文ごとのチャット履歴を初期化（Neo4jから取得）
                     if active_id not in st.session_state.chat_histories:
-                        st.session_state.chat_histories[active_id] = []
+                        try:
+                            persisted = api_get_chat_history(active_id)
+                            st.session_state.chat_histories[active_id] = persisted
+                        except Exception:
+                            st.session_state.chat_histories[active_id] = []
 
                     chat_history = st.session_state.chat_histories[active_id]
 


### PR DESCRIPTION
## Summary
This PR adds persistent chat history storage to Neo4j and implements authentication requirements for chat-related endpoints. Users can now resume conversations about papers across sessions, with chat history automatically saved and retrieved from the database.

## Key Changes

**Backend (main.py):**
- Added `json` import for serializing chat history
- Created new `ChatHistoryResponse` model for the history endpoint
- Added authentication requirement to `POST /api/chat` endpoint via `_get_current_user` dependency
- Implemented chat history persistence: after each chat response, the updated conversation history is saved to Neo4j as a JSON string on the `CHATTED_ABOUT` relationship between User and Paper nodes
- Added new `GET /api/chat/history/{arxiv_id}` endpoint to retrieve persisted chat history for the current user and specified paper
- Graceful error handling for history persistence failures (logged but doesn't block chat response)

**Frontend (app.py):**
- Created `_auth_headers()` helper function to include Bearer token in API requests
- Updated all API calls to include authentication headers: `api_search()`, `api_fetch()`, `api_presigned_url()`, `api_list_papers()`, `api_extract()`, `api_extract_status()`, `api_get_extract_result()`, `api_update_extract_result()`, and `api_chat()`
- Added new `api_get_chat_history()` function to fetch persisted chat history from Neo4j
- Modified chat history initialization to load persisted history from Neo4j instead of starting empty, with fallback to empty list on errors

## Implementation Details
- Chat history is stored as a JSON string on Neo4j relationship properties to maintain conversation context across sessions
- The `CHATTED_ABOUT` relationship is created/merged between User and Paper nodes, ensuring one relationship per user-paper pair
- All chat-related operations now require authentication, preventing unauthorized access to chat functionality
- History retrieval gracefully handles missing records by returning an empty history list

https://claude.ai/code/session_01DShV4vtk2cSDNjhWVUr7JC