### PR TITLE
feat: complete LLM Gateway layer for structure proposal review and merge

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -174,6 +174,23 @@ class ProposeStructureResponse(BaseModel):
     status: str = "pending"
 
 
+class ProposalItem(BaseModel):
+    """Single proposal entry returned by GET /api/proposals/{arxiv_id}."""
+
+    proposal_id: str
+    user_id: str
+    username: str | None = None
+    status: str
+    evaluation_reasoning: str | None = None
+    created_at: str | None = None
+
+
+class ProposalListResponse(BaseModel):
+    """List of proposals for a given paper."""
+
+    proposals: list[ProposalItem]
+
+
 class RegisterRequest(BaseModel):
     username: str
     email: str
@@ -571,7 +588,24 @@ def _run_review_task(proposal: StructureProposal) -> None:
         reasoning = "LLM review encountered an error."
         merged_json = ""
 
-    # 3. Neo4j の提案ノードを更新
+    # 3. 承認された場合、MinIO の正典構造を merged_structure で上書き更新
+    if new_status == "approved" and merged_json:
+        try:
+            merged_bytes = merged_json.encode()
+            _storage().client.put_object(
+                "extracted-structures",
+                f"{safe_id}.json",
+                io.BytesIO(merged_bytes),
+                length=len(merged_bytes),
+                content_type="application/json",
+            )
+            logger.info("Updated canonical structure in MinIO for %s", proposal.arxiv_id)
+        except Exception:
+            logger.exception(
+                "Failed to update MinIO with merged structure for %s", proposal.arxiv_id
+            )
+
+    # 4. Neo4j の提案ノードを更新
     with driver.session() as session:
         session.run(
             """
@@ -617,6 +651,7 @@ def propose_structure(
     )
 
     # Neo4j への保存
+    created_at = datetime.datetime.utcnow().isoformat()
     try:
         driver = get_driver()
         with driver.session() as session:
@@ -628,7 +663,8 @@ def propose_structure(
                     arxiv_id:           $arxiv_id,
                     user_id:            $user_id,
                     proposed_structure: $proposed_structure,
-                    status:             'pending'
+                    status:             'pending',
+                    created_at:         $created_at
                 })
                 CREATE (u)-[:PROPOSED]->(p)
                 """,
@@ -636,6 +672,7 @@ def propose_structure(
                 proposal_id=proposal_id,
                 arxiv_id=body.arxiv_id,
                 proposed_structure=body.proposed_structure.model_dump_json(),
+                created_at=created_at,
             )
     except Exception as exc:
         logger.exception("Failed to save proposal %s to Neo4j", proposal_id)
@@ -646,6 +683,46 @@ def propose_structure(
     logger.info("Proposal %s queued for LLM review (arxiv_id=%s)", proposal_id, body.arxiv_id)
 
     return ProposeStructureResponse(proposal_id=proposal_id, status="pending")
+
+
+@app.get("/api/proposals/{arxiv_id}", response_model=ProposalListResponse)
+def get_proposals(
+    arxiv_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> ProposalListResponse:
+    """指定論文に対する全提案履歴を Neo4j から取得して返す。
+
+    StructureProposal ノードを arxiv_id で絞り込み、提案者のユーザー名・ステータス・
+    LLM 評価理由などをリスト形式で返す。
+    """
+    driver = get_driver()
+    with driver.session() as session:
+        records = session.run(
+            """
+            MATCH (u:User)-[:PROPOSED]->(p:StructureProposal {arxiv_id: $arxiv_id})
+            RETURN p.proposal_id       AS proposal_id,
+                   p.user_id           AS user_id,
+                   u.username          AS username,
+                   p.status            AS status,
+                   p.evaluation_reasoning AS evaluation_reasoning,
+                   p.created_at        AS created_at
+            ORDER BY p.created_at DESC
+            """,
+            arxiv_id=arxiv_id,
+        ).data()
+
+    proposals = [
+        ProposalItem(
+            proposal_id=r["proposal_id"],
+            user_id=r["user_id"],
+            username=r.get("username"),
+            status=r["status"] or "pending",
+            evaluation_reasoning=r.get("evaluation_reasoning"),
+            created_at=r.get("created_at"),
+        )
+        for r in records
+    ]
+    return ProposalListResponse(proposals=proposals)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -54,6 +54,9 @@ if "user_id" not in st.session_state:
     st.session_state.user_id: str | None = None
 if "username" not in st.session_state:
     st.session_state.username: str | None = None
+# 提案中の論文: arxiv_id -> proposal_id (直近に送信した提案を追跡)
+if "pending_proposals" not in st.session_state:
+    st.session_state.pending_proposals: dict[str, str] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +223,33 @@ def api_get_chat_history(arxiv_id: str) -> list[dict]:
         return []
     resp.raise_for_status()
     return resp.json().get("history", [])
+
+
+def api_propose_structure(arxiv_id: str, structure: dict) -> dict:
+    """POST /api/propose-structure — submit edited structure for LLM gateway review."""
+    resp = requests.post(
+        f"{BACKEND_URL}/api/propose-structure",
+        json={
+            "arxiv_id": arxiv_id,
+            "user_id": st.session_state.user_id,
+            "proposed_structure": structure,
+        },
+        headers=_auth_headers(),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()  # {proposal_id, status: "pending"}
+
+
+def api_get_proposals(arxiv_id: str) -> dict:
+    """GET /api/proposals/{arxiv_id} — fetch proposal history from Neo4j."""
+    resp = requests.get(
+        f"{BACKEND_URL}/api/proposals/{arxiv_id}",
+        headers=_auth_headers(),
+        timeout=15,
+    )
+    resp.raise_for_status()
+    return resp.json()  # {proposals: [...]}
 
 
 def _auth_post(path: str, payload: dict) -> dict:
@@ -611,7 +641,9 @@ elif page == "Validation View":
 
             # ── Structure Editor + Chat ───────────────────────────────────────
             with edit_col:
-                struct_tab, chat_tab = st.tabs(["📄 Extracted Structure", "💬 Chat"])
+                struct_tab, chat_tab, proposals_tab = st.tabs(
+                    ["📄 Extracted Structure", "💬 Chat", "📋 提案履歴"]
+                )
 
                 # ── Structure Editor tab ──────────────────────────────────────
                 with struct_tab:
@@ -692,13 +724,13 @@ elif page == "Validation View":
                                 height=110,
                             )
 
-                        save = st.form_submit_button(
-                            "💾 Save edits",
+                        propose = st.form_submit_button(
+                            "💡 変更を提案する (Propose)",
                             use_container_width=True,
                             type="primary",
                         )
 
-                    if save:
+                    if propose:
                         try:
                             edges_parsed = json.loads(edges_json)
                         except Exception:
@@ -735,13 +767,17 @@ elif page == "Validation View":
                         }
                         st.session_state.structures[active_id] = updated
 
-                        # Sync to backend / MinIO
+                        # LLM Gateway へ提案を送信
                         try:
-                            api_update_extract_result(active_id, updated)
-                            st.success("Edits saved and synced to MinIO.")
+                            result = api_propose_structure(active_id, updated)
+                            proposal_id = result.get("proposal_id", "")
+                            st.session_state.pending_proposals[active_id] = proposal_id
+                            st.toast(
+                                "提案を送信しました。AIがレビュー・マージを行います",
+                                icon="💡",
+                            )
                         except Exception as exc:
-                            st.success("Edits saved locally.")
-                            st.warning(f"Backend sync failed: {exc}")
+                            st.error(f"提案の送信に失敗しました: {exc}")
 
                 # ── Chat tab ──────────────────────────────────────────────────
                 with chat_tab:
@@ -805,3 +841,74 @@ elif page == "Validation View":
                                 except Exception as exc:
                                     error_msg = f"チャットエラー: {exc}"
                                     st.error(error_msg)
+
+                # ── Proposals History tab ─────────────────────────────────────
+                with proposals_tab:
+                    st.markdown("### 提案履歴 (LLM Gateway)")
+                    st.caption(
+                        "「💡 変更を提案する」で送信した編集内容とAIの審査・マージ結果を確認できます。"
+                    )
+
+                    # 直近提案のペンディング状態インジケーター
+                    if active_id in st.session_state.pending_proposals:
+                        st.info(
+                            "⏳ **AIによるレビューが進行中です。** "
+                            "しばらく後にこのページを更新してください。",
+                            icon="⏳",
+                        )
+
+                    col_refresh, _ = st.columns([1, 4])
+                    with col_refresh:
+                        if st.button("🔄 更新", key=f"refresh_proposals_{active_id}"):
+                            st.rerun()
+
+                    try:
+                        proposals_data = api_get_proposals(active_id)
+                        proposals_list = proposals_data.get("proposals", [])
+                    except Exception as exc:
+                        st.error(f"提案履歴の取得に失敗しました: {exc}")
+                        proposals_list = []
+
+                    if not proposals_list:
+                        st.info("この論文に対する提案履歴はまだありません。")
+                    else:
+                        _PROPOSAL_STATUS_ICON = {
+                            "approved": "✅",
+                            "failed": "❌",
+                            "pending": "⏳",
+                        }
+                        for _p in proposals_list:
+                            _p_status = _p.get("status", "pending")
+                            _p_icon = _PROPOSAL_STATUS_ICON.get(_p_status, "🟡")
+                            _p_id_short = _p.get("proposal_id", "")[:8]
+                            _p_username = _p.get("username") or _p.get("user_id", "")
+                            _p_created = _p.get("created_at", "")
+
+                            # ペンディング解消チェック
+                            _tracked_id = st.session_state.pending_proposals.get(active_id)
+                            if (
+                                _tracked_id == _p.get("proposal_id")
+                                and _p_status in ("approved", "failed")
+                            ):
+                                st.session_state.pending_proposals.pop(active_id, None)
+
+                            with st.container(border=True):
+                                _head_col, _status_col = st.columns([3, 1])
+                                with _head_col:
+                                    st.markdown(
+                                        f"**提案 `{_p_id_short}…`**  |  👤 {_p_username}"
+                                    )
+                                    if _p_created:
+                                        st.caption(f"提出日時: {_p_created}")
+                                with _status_col:
+                                    st.markdown(f"## {_p_icon}")
+                                    st.caption(_p_status.upper())
+
+                                _reasoning = _p.get("evaluation_reasoning")
+                                if _reasoning:
+                                    with st.expander("AIの評価理由を見る"):
+                                        st.markdown(_reasoning)
+                                elif _p_status == "pending":
+                                    st.caption("AIによる評価待ちです。")
+                                else:
+                                    st.caption("評価理由が記録されていません。")


### PR DESCRIPTION
## Backend (backend/main.py)

- Task 1-1: _run_review_task now writes the approved merged_structure back to MinIO extracted-structures/{safe_id}.json, making the canonical structure reflect LLM-reviewed proposals automatically.
- Task 1-2: Add GET /api/proposals/{arxiv_id} endpoint (auth-protected) that queries Neo4j for StructureProposal nodes, returning proposal_id, username, status, evaluation_reasoning and created_at for timeline UI.
- Add ProposalItem and ProposalListResponse Pydantic models.
- Add created_at ISO timestamp to StructureProposal creation in Neo4j.

## Frontend (frontend/app.py)

- Task 2-1: Replace "💾 Save edits" with "💡 変更を提案する (Propose)" button that calls POST /api/propose-structure (LLM gateway) instead of directly overwriting MinIO via PUT.
- Task 2-2: Show st.toast notification after successful proposal submission; track pending proposals in pending_proposals session state dict.
- Task 2-3: Add "📋 提案履歴" tab to the right-column editor panel that calls GET /api/proposals/{arxiv_id} and renders a timeline of past proposals with status icons, submitter info, timestamps, and expandable LLM evaluation_reasoning per proposal.
- Add api_propose_structure() and api_get_proposals() helper functions with Bearer token headers.

https://claude.ai/code/session_01R1eFnvVhTCzh8C9cbAenVG