### PR TITLE
Add draft management and pattern registration workflow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,11 @@ GET  /api/extract-result/{arxiv_id}     Fetch a previously extracted paper struc
 PUT  /api/extract-result/{arxiv_id}     Update an extracted paper structure in MinIO.
 GET  /api/presigned-url                 Return a browser-accessible pre-signed URL for a stored PDF.
 GET  /api/papers                        List all stored paper object names.
+GET  /api/draft/{arxiv_id}              Get user's private draft from Neo4j.
+PUT  /api/draft/{arxiv_id}              Save/upsert user's private draft in Neo4j.
 POST /api/propose-structure             Submit a user structure proposal (saved to Neo4j, async LLM review).
+POST /api/patterns/extract/{arxiv_id}   Preview pattern extraction (no DB save).
+POST /api/patterns/register             Register a confirmed pattern to Qdrant/Neo4j.
 POST /api/auth/register                 Register a new user (Neo4j User node, returns JWT).
 POST /api/auth/login                    Authenticate and return a JWT.
 GET  /api/auth/me                       Return the current user's profile (requires Bearer token).
@@ -125,6 +129,8 @@ class PresignedUrlResponse(BaseModel):
 class ExtractRequest(BaseModel):
     object_name: str
     arxiv_id: str
+    is_draft: bool = False
+    user_id: str | None = None
 
 
 class ExtractAccepted(BaseModel):
@@ -261,6 +267,32 @@ class PaperPatternListResponse(BaseModel):
     matches: list[PatternMatchOut]
 
 
+class DraftResponse(BaseModel):
+    """Response for GET /api/draft/{arxiv_id}."""
+
+    arxiv_id: str
+    structure: PaperStructure
+
+
+class DraftSaveRequest(BaseModel):
+    """Request body for PUT /api/draft/{arxiv_id}."""
+
+    structure: PaperStructure
+
+
+class PatternRegisterRequest(BaseModel):
+    """Request body for POST /api/patterns/register."""
+
+    pattern: AbstractionPattern
+
+
+class PatternRegisterResponse(BaseModel):
+    """Response for POST /api/patterns/register."""
+
+    pattern_id: str
+    status: str = "registered"
+
+
 # ---------------------------------------------------------------------------
 # Auth utility functions
 # ---------------------------------------------------------------------------
@@ -302,13 +334,19 @@ def _get_current_user(
 # Background extraction task
 # ---------------------------------------------------------------------------
 
-def _run_extraction_task(object_name: str, arxiv_id: str) -> None:
+def _run_extraction_task(
+    object_name: str,
+    arxiv_id: str,
+    is_draft: bool = False,
+    user_id: str | None = None,
+) -> None:
     """バックグラウンドで実行される抽出タスク。
 
     1. ステータスを "processing" に更新
     2. MinIO から PDF を取得
     3. テキスト抽出 → 仮説検証型チャンク解析 → Embedding（並行）
-    4. 結果を MinIO に保存
+    4. is_draft=False の場合は MinIO に保存（従来どおり）、
+       is_draft=True の場合は Neo4j のユーザードラフトとして保存
     5. ステータスを "completed" または "failed" に更新
     """
     with _job_lock:
@@ -316,7 +354,7 @@ def _run_extraction_task(object_name: str, arxiv_id: str) -> None:
 
     try:
         # 1. Fetch PDF from MinIO
-        logger.info("Background extraction started for %s", arxiv_id)
+        logger.info("Background extraction started for %s (is_draft=%s)", arxiv_id, is_draft)
         response = _storage().client.get_object("raw-papers", object_name)
         pdf_bytes = response.read()
         response.close()
@@ -326,17 +364,37 @@ def _run_extraction_task(object_name: str, arxiv_id: str) -> None:
         text = ext.extract_text_from_pdf_bytes(pdf_bytes)
         structure = ext.extract_paper_structure(text, paper_id=arxiv_id)
 
-        # 3. Persist JSON to extracted-structures bucket
-        json_bytes = structure.model_dump_json().encode()
-        safe_id = arxiv_id.replace("/", "_")
-        _storage().client.put_object(
-            "extracted-structures",
-            f"{safe_id}.json",
-            io.BytesIO(json_bytes),
-            length=len(json_bytes),
-            content_type="application/json",
-        )
-        logger.info("Background extraction completed for %s", arxiv_id)
+        if is_draft and user_id:
+            # 3a. ドラフトモード: Neo4j のユーザードラフトとして保存
+            structure_json = structure.model_dump_json()
+            driver = get_driver()
+            with driver.session() as session:
+                session.run(
+                    """
+                    MERGE (u:User {id: $user_id})
+                    MERGE (d:Draft {arxiv_id: $arxiv_id, user_id: $user_id})
+                    MERGE (u)-[:HAS_DRAFT]->(d)
+                    SET d.structure = $structure_json,
+                        d.updated_at = $updated_at
+                    """,
+                    user_id=user_id,
+                    arxiv_id=arxiv_id,
+                    structure_json=structure_json,
+                    updated_at=datetime.datetime.utcnow().isoformat(),
+                )
+            logger.info("Draft extraction saved to Neo4j for %s (user=%s)", arxiv_id, user_id)
+        else:
+            # 3b. 通常モード: MinIO の extracted-structures バケットに保存
+            json_bytes = structure.model_dump_json().encode()
+            safe_id = arxiv_id.replace("/", "_")
+            _storage().client.put_object(
+                "extracted-structures",
+                f"{safe_id}.json",
+                io.BytesIO(json_bytes),
+                length=len(json_bytes),
+                content_type="application/json",
+            )
+            logger.info("Background extraction completed for %s", arxiv_id)
 
         with _job_lock:
             _job_status[arxiv_id] = ExtractJobStatus(arxiv_id=arxiv_id, status="completed")
@@ -417,13 +475,22 @@ def extract(body: ExtractRequest, background_tasks: BackgroundTasks) -> ExtractA
 
     Returns immediately with status="pending".
     Poll ``GET /api/extract-status/{arxiv_id}`` to track progress.
+
+    When ``is_draft=True`` and ``user_id`` is provided, the extraction result is
+    saved as a private Neo4j draft instead of overwriting the canonical MinIO store.
     """
     with _job_lock:
         _job_status[body.arxiv_id] = ExtractJobStatus(
             arxiv_id=body.arxiv_id, status="pending"
         )
-    background_tasks.add_task(_run_extraction_task, body.object_name, body.arxiv_id)
-    logger.info("Extraction job queued for %s", body.arxiv_id)
+    background_tasks.add_task(
+        _run_extraction_task,
+        body.object_name,
+        body.arxiv_id,
+        is_draft=body.is_draft,
+        user_id=body.user_id,
+    )
+    logger.info("Extraction job queued for %s (is_draft=%s)", body.arxiv_id, body.is_draft)
     return ExtractAccepted(arxiv_id=body.arxiv_id, status="pending")
 
 
@@ -516,6 +583,63 @@ def update_extract_result(arxiv_id: str, body: PaperStructure) -> PaperStructure
         logger.exception("Failed to update extract result in MinIO")
         raise HTTPException(status_code=500, detail=f"Update failed: {exc}") from exc
     return body
+
+
+@app.get("/api/draft/{arxiv_id}", response_model=DraftResponse)
+def get_draft(
+    arxiv_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> DraftResponse:
+    """ログインユーザーの指定論文に対するプライベートドラフトを Neo4j から取得する。"""
+    driver = get_driver()
+    with driver.session() as session:
+        record = session.run(
+            """
+            MATCH (u:User {id: $user_id})-[:HAS_DRAFT]->(d:Draft {arxiv_id: $arxiv_id})
+            RETURN d.structure AS structure
+            """,
+            user_id=current_user["id"],
+            arxiv_id=arxiv_id,
+        ).single()
+
+    if not record or not record["structure"]:
+        raise HTTPException(status_code=404, detail="No draft found")
+
+    try:
+        structure = PaperStructure.model_validate_json(record["structure"])
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to parse draft structure: {exc}"
+        ) from exc
+
+    return DraftResponse(arxiv_id=arxiv_id, structure=structure)
+
+
+@app.put("/api/draft/{arxiv_id}", response_model=DraftResponse)
+def save_draft(
+    arxiv_id: str,
+    body: DraftSaveRequest,
+    current_user: dict = Depends(_get_current_user),
+) -> DraftResponse:
+    """ログインユーザーのドラフトを Neo4j に保存（UPSERT）する。"""
+    structure_json = body.structure.model_dump_json()
+    driver = get_driver()
+    with driver.session() as session:
+        session.run(
+            """
+            MERGE (u:User {id: $user_id})
+            MERGE (d:Draft {arxiv_id: $arxiv_id, user_id: $user_id})
+            MERGE (u)-[:HAS_DRAFT]->(d)
+            SET d.structure = $structure_json,
+                d.updated_at = $updated_at
+            """,
+            user_id=current_user["id"],
+            arxiv_id=arxiv_id,
+            structure_json=structure_json,
+            updated_at=datetime.datetime.utcnow().isoformat(),
+        )
+    logger.info("Draft saved for user=%s arxiv_id=%s", current_user["id"], arxiv_id)
+    return DraftResponse(arxiv_id=arxiv_id, structure=body.structure)
 
 
 @app.post("/api/chat", response_model=ChatResponse)
@@ -839,18 +963,34 @@ def auth_me(current_user: dict = Depends(_get_current_user)) -> UserOut:
 # Background pattern extraction + batch evaluation task
 # ---------------------------------------------------------------------------
 
-def _run_pattern_extraction_task(arxiv_id: str) -> None:
-    """バックグラウンドで実行されるパターン抽出 + 再評価バッチタスク。
+def _run_pattern_evaluation_task(pattern: AbstractionPattern) -> None:
+    """バックグラウンドで実行されるパターン再評価バッチタスク。
 
-    1. MinIO から PaperStructure をロード
-    2. LLM でパターンを抽出
-    3. Neo4j にパターンノードを保存
-    4. Qdrant にパターンの Embedding を保存
-    5. 過去の論文に対して構造的同型性を評価（バッチ）
+    登録済みパターンに対して、過去の論文への構造的同型性を評価する。
     """
-    logger.info("Pattern extraction started for %s", arxiv_id)
+    try:
+        matches = run_pattern_evaluation_task(pattern, _storage().client)
+        logger.info(
+            "Batch evaluation completed for pattern %s: %d matches",
+            pattern.pattern_id, len(matches),
+        )
+    except Exception:
+        logger.exception("Batch evaluation failed for pattern %s", pattern.pattern_id)
 
-    # 1. PaperStructure をロード
+
+# ---------------------------------------------------------------------------
+# Pattern API endpoints
+# ---------------------------------------------------------------------------
+
+@app.post("/api/patterns/extract/{arxiv_id}", response_model=AbstractionPattern)
+def extract_pattern_preview(
+    arxiv_id: str,
+) -> AbstractionPattern:
+    """指定論文から抽象化パターンを抽出し、プレビュー用にレスポンスとして返す。
+
+    DB（Qdrant / Neo4j）には保存しない。ユーザーが結果を確認・修正した後、
+    ``POST /api/patterns/register`` で正式登録する。
+    """
     safe_id = arxiv_id.replace("/", "_")
     try:
         response = _storage().client.get_object("extracted-structures", f"{safe_id}.json")
@@ -859,19 +999,37 @@ def _run_pattern_extraction_task(arxiv_id: str) -> None:
         response.release_conn()
         structure = PaperStructure.model_validate_json(data)
     except Exception:
-        logger.exception("Failed to load PaperStructure for %s", arxiv_id)
-        return
+        raise HTTPException(
+            status_code=404,
+            detail=f"No extracted structure found for '{arxiv_id}'. Extract the paper first.",
+        )
 
-    # 2. LLM でパターン抽出
     try:
         pattern = ext.extract_abstraction_pattern(structure)
-    except Exception:
-        logger.exception("Pattern extraction failed for %s", arxiv_id)
-        return
+    except Exception as exc:
+        logger.exception("Pattern extraction preview failed for %s", arxiv_id)
+        raise HTTPException(
+            status_code=500, detail=f"Pattern extraction failed: {exc}"
+        ) from exc
 
-    logger.info("Pattern extracted: %s (id=%s)", pattern.name, pattern.pattern_id)
+    logger.info("Pattern preview generated for %s: %s", arxiv_id, pattern.name)
+    return pattern
 
-    # 3. Neo4j にパターンノードを保存
+
+@app.post("/api/patterns/register", response_model=PatternRegisterResponse)
+def register_pattern(
+    body: PatternRegisterRequest,
+    background_tasks: BackgroundTasks,
+) -> PatternRegisterResponse:
+    """ユーザーが確認・修正済みの AbstractionPattern を正式に登録する。
+
+    1. Neo4j にパターンノードを保存
+    2. Qdrant にパターンの Embedding を保存
+    3. 過去論文に対する再評価バッチをバックグラウンドでトリガー
+    """
+    pattern = body.pattern
+
+    # 1. Neo4j にパターンノードを保存
     try:
         driver = get_driver()
         with driver.session() as session:
@@ -895,12 +1053,14 @@ def _run_pattern_extraction_task(arxiv_id: str) -> None:
                 structural_rules=json.dumps(pattern.structural_rules),
                 source_arxiv_id=pattern.source_arxiv_id,
             )
-        logger.info("Pattern %s saved to Neo4j", pattern.pattern_id)
-    except Exception:
-        logger.exception("Failed to save pattern %s to Neo4j", pattern.pattern_id)
-        return
+        logger.info("Pattern %s registered in Neo4j", pattern.pattern_id)
+    except Exception as exc:
+        logger.exception("Failed to register pattern %s in Neo4j", pattern.pattern_id)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to register pattern: {exc}"
+        ) from exc
 
-    # 4. Qdrant にパターンの Embedding を保存
+    # 2. Qdrant にパターンの Embedding を保存
     try:
         client = get_client()
         settings = get_settings()
@@ -913,45 +1073,17 @@ def _run_pattern_extraction_task(arxiv_id: str) -> None:
             embedding_model=settings.embedding_model,
         )
     except Exception:
-        logger.warning("Pattern embedding failed for %s (continuing)", pattern.pattern_id, exc_info=True)
-
-    # 5. 過去の論文に対してバッチ評価
-    try:
-        matches = run_pattern_evaluation_task(pattern, _storage().client)
-        logger.info(
-            "Batch evaluation completed for pattern %s: %d matches",
-            pattern.pattern_id, len(matches),
-        )
-    except Exception:
-        logger.exception("Batch evaluation failed for pattern %s", pattern.pattern_id)
-
-
-# ---------------------------------------------------------------------------
-# Pattern API endpoints
-# ---------------------------------------------------------------------------
-
-@app.post("/api/patterns/extract/{arxiv_id}", response_model=PatternExtractAccepted)
-def extract_pattern(
-    arxiv_id: str,
-    background_tasks: BackgroundTasks,
-) -> PatternExtractAccepted:
-    """指定論文から抽象化パターンを抽出するバックグラウンドジョブを開始する。
-
-    パターン抽出後、自動的に過去論文への再評価バッチも実行される。
-    """
-    # PaperStructure が存在するか確認
-    safe_id = arxiv_id.replace("/", "_")
-    try:
-        _storage().client.stat_object("extracted-structures", f"{safe_id}.json")
-    except Exception:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No extracted structure found for '{arxiv_id}'. Extract the paper first.",
+        logger.warning(
+            "Pattern embedding failed for %s (continuing)", pattern.pattern_id, exc_info=True
         )
 
-    background_tasks.add_task(_run_pattern_extraction_task, arxiv_id)
-    logger.info("Pattern extraction job queued for %s", arxiv_id)
-    return PatternExtractAccepted(arxiv_id=arxiv_id, status="pending")
+    # 3. バックグラウンドで過去論文に対する再評価バッチをトリガー
+    background_tasks.add_task(
+        _run_pattern_evaluation_task, pattern
+    )
+
+    logger.info("Pattern %s fully registered, batch evaluation queued", pattern.pattern_id)
+    return PatternRegisterResponse(pattern_id=pattern.pattern_id, status="registered")
 
 
 @app.get("/api/patterns", response_model=PatternListResponse)

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -57,6 +57,12 @@ if "username" not in st.session_state:
 # 提案中の論文: arxiv_id -> proposal_id (直近に送信した提案を追跡)
 if "pending_proposals" not in st.session_state:
     st.session_state.pending_proposals: dict[str, str] = {}
+# ドラフトが存在する論文を追跡: arxiv_id -> True
+if "draft_papers" not in st.session_state:
+    st.session_state.draft_papers: dict[str, bool] = {}
+# パターンプレビュー結果: arxiv_id -> pattern dict
+if "pattern_preview" not in st.session_state:
+    st.session_state.pattern_preview: dict[str, dict] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -82,12 +88,23 @@ def _poll_processing_papers() -> None:
         status = status_data.get("status", "")
 
         if status == "completed":
-            # 構造を自動ロード
+            # 構造を自動ロード: まずドラフトを試行、なければ正典
+            _loaded_from_draft = False
             try:
-                result = api_get_extract_result(arxiv_id)
-                st.session_state.structures[arxiv_id] = result
+                _draft = api_get_draft(arxiv_id)
+                if _draft is not None:
+                    st.session_state.structures[arxiv_id] = _draft["structure"]
+                    st.session_state.draft_papers[arxiv_id] = True
+                    _loaded_from_draft = True
             except Exception:
                 pass
+            if not _loaded_from_draft:
+                try:
+                    result = api_get_extract_result(arxiv_id)
+                    st.session_state.structures[arxiv_id] = result
+                    st.session_state.draft_papers.pop(arxiv_id, None)
+                except Exception:
+                    pass
             title = info.get("title", arxiv_id)
             del st.session_state.processing_papers[arxiv_id]
             st.toast(f"解析が完了しました！", icon="✅")
@@ -153,11 +170,17 @@ def api_list_papers() -> list[str]:
     return resp.json()
 
 
-def api_extract(object_name: str, arxiv_id: str) -> dict:
+def api_extract(
+    object_name: str, arxiv_id: str, is_draft: bool = False, user_id: str | None = None
+) -> dict:
     """POST /api/extract — submit async job, returns {arxiv_id, status: "pending"}."""
+    payload: dict = {"object_name": object_name, "arxiv_id": arxiv_id}
+    if is_draft:
+        payload["is_draft"] = True
+        payload["user_id"] = user_id
     resp = requests.post(
         f"{BACKEND_URL}/api/extract",
-        json={"object_name": object_name, "arxiv_id": arxiv_id},
+        json=payload,
         headers=_auth_headers(),
         timeout=30,
     )
@@ -253,11 +276,11 @@ def api_get_proposals(arxiv_id: str) -> dict:
 
 
 def api_extract_pattern(arxiv_id: str) -> dict:
-    """POST /api/patterns/extract/{arxiv_id} — trigger pattern extraction."""
+    """POST /api/patterns/extract/{arxiv_id} — preview pattern extraction (synchronous)."""
     resp = requests.post(
         f"{BACKEND_URL}/api/patterns/extract/{arxiv_id}",
         headers=_auth_headers(),
-        timeout=30,
+        timeout=120,
     )
     resp.raise_for_status()
     return resp.json()
@@ -283,6 +306,46 @@ def api_get_paper_patterns(arxiv_id: str) -> list[dict]:
     )
     resp.raise_for_status()
     return resp.json().get("matches", [])
+
+
+def api_get_draft(arxiv_id: str) -> dict | None:
+    """GET /api/draft/{arxiv_id} — fetch user's private draft from Neo4j.
+
+    Returns the draft structure dict, or None if no draft exists (404).
+    """
+    resp = requests.get(
+        f"{BACKEND_URL}/api/draft/{arxiv_id}",
+        headers=_auth_headers(),
+        timeout=15,
+    )
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()  # {arxiv_id, structure: {...}}
+
+
+def api_save_draft(arxiv_id: str, structure: dict) -> dict:
+    """PUT /api/draft/{arxiv_id} — save structure as user's private draft."""
+    resp = requests.put(
+        f"{BACKEND_URL}/api/draft/{arxiv_id}",
+        json={"structure": structure},
+        headers=_auth_headers(),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_register_pattern(pattern: dict) -> dict:
+    """POST /api/patterns/register — register a confirmed pattern to Qdrant/Neo4j."""
+    resp = requests.post(
+        f"{BACKEND_URL}/api/patterns/register",
+        json={"pattern": pattern},
+        headers=_auth_headers(),
+        timeout=60,
+    )
+    resp.raise_for_status()
+    return resp.json()  # {pattern_id, status: "registered"}
 
 
 def _auth_post(path: str, payload: dict) -> dict:
@@ -592,17 +655,28 @@ elif page == "Validation View":
             object_name = stored[active_id]
             is_processing = active_id in st.session_state.processing_papers
 
-            # 処理中の場合は最新の構造を自動リロード
-            if active_id in st.session_state.structures:
-                s = st.session_state.structures[active_id]
-            else:
-                # MinIO から取得を試みる（完了済みかもしれない）
+            # ── ドラフト優先ロジック: まずユーザーのドラフトを取得、なければ正典を取得
+            _is_draft_view = False
+            if active_id not in st.session_state.structures:
+                # ドラフトを試行
                 try:
-                    _loaded = api_get_extract_result(active_id)
-                    st.session_state.structures[active_id] = _loaded
-                    s = _loaded
+                    _draft_resp = api_get_draft(active_id)
+                    if _draft_resp is not None:
+                        st.session_state.structures[active_id] = _draft_resp["structure"]
+                        st.session_state.draft_papers[active_id] = True
                 except Exception:
-                    s = _empty_structure(active_id)
+                    pass
+                # ドラフトがなければ MinIO の正典を取得
+                if active_id not in st.session_state.structures:
+                    try:
+                        _loaded = api_get_extract_result(active_id)
+                        st.session_state.structures[active_id] = _loaded
+                        st.session_state.draft_papers.pop(active_id, None)
+                    except Exception:
+                        st.session_state.structures[active_id] = _empty_structure(active_id)
+
+            s = st.session_state.structures[active_id]
+            _is_draft_view = st.session_state.draft_papers.get(active_id, False)
 
             status = s.get("review_status", "pending")
             title = (
@@ -617,9 +691,18 @@ elif page == "Validation View":
                 st.info("バックグラウンドで解析処理中です。完了次第自動的に更新されます。")
             else:
                 st.title(title)
-            st.caption(
-                f"arXiv ID: `{active_id}`  |  Status: {_STATUS_LABEL.get(status, '🟡 Pending')}"
-            )
+
+            # ── ドラフト / 正典バッジ ────────────────────────────────────────
+            _badge_col, _status_col = st.columns([1, 3])
+            with _badge_col:
+                if _is_draft_view:
+                    st.info("📝 あなたの未公開ドラフト")
+                else:
+                    st.success("🏛️ システム正規テンプレート")
+            with _status_col:
+                st.caption(
+                    f"arXiv ID: `{active_id}`  |  Status: {_STATUS_LABEL.get(status, '🟡 Pending')}"
+                )
 
             # ── Action buttons (right-aligned) ───────────────────────────────
             _, act1, act2, act3, act4 = st.columns([5, 1, 1, 1, 1])
@@ -644,22 +727,30 @@ elif page == "Validation View":
             with act3:
                 if st.button("🔄 Re-Extract", use_container_width=True, key="btn_reextract"):
                     try:
-                        api_extract(object_name, active_id)
+                        api_extract(
+                            object_name,
+                            active_id,
+                            is_draft=True,
+                            user_id=st.session_state.user_id,
+                        )
                         st.session_state.processing_papers[active_id] = {
                             "title": title,
                             "object_name": object_name,
                         }
-                        st.toast(f"⏳ 「{title}」 の再解析を開始しました")
+                        st.toast(f"⏳ 「{title}」 の再解析を開始しました（ドラフトとして保存されます）")
                         st.rerun()
                     except Exception as exc:
                         st.error(f"Re-extraction failed: {exc}")
             with act4:
                 if st.button("✨ Pattern", use_container_width=True, key="btn_pattern"):
                     try:
-                        api_extract_pattern(active_id)
-                        st.toast("✨ 抽象化パターンの抽出を開始しました")
+                        with st.spinner("パターンを抽出中…"):
+                            _preview = api_extract_pattern(active_id)
+                            st.session_state.pattern_preview[active_id] = _preview
+                        st.rerun()
                     except Exception as exc:
                         st.error(f"Pattern extraction failed: {exc}")
+            # 💾 Save edits is inside the structure editor form below
 
             st.divider()
 
@@ -782,13 +873,21 @@ elif page == "Validation View":
                                 height=110,
                             )
 
-                        propose = st.form_submit_button(
-                            "💡 変更を提案する (Propose)",
-                            use_container_width=True,
-                            type="primary",
-                        )
+                        _btn_col1, _btn_col2 = st.columns(2)
+                        with _btn_col1:
+                            save_draft_btn = st.form_submit_button(
+                                "💾 Save edits",
+                                use_container_width=True,
+                            )
+                        with _btn_col2:
+                            propose = st.form_submit_button(
+                                "💡 変更を提案する (Propose)",
+                                use_container_width=True,
+                                type="primary",
+                            )
 
-                    if propose:
+                    # ── フォーム送信後の共通処理: 編集内容を dict に変換 ────
+                    if save_draft_btn or propose:
                         try:
                             edges_parsed = json.loads(edges_json)
                         except Exception:
@@ -825,6 +924,16 @@ elif page == "Validation View":
                         }
                         st.session_state.structures[active_id] = updated
 
+                    if save_draft_btn:
+                        # ドラフトとして Neo4j に保存
+                        try:
+                            api_save_draft(active_id, updated)
+                            st.session_state.draft_papers[active_id] = True
+                            st.toast("ドラフトを保存しました", icon="💾")
+                        except Exception as exc:
+                            st.error(f"ドラフトの保存に失敗しました: {exc}")
+
+                    if propose:
                         # LLM Gateway へ提案を送信
                         try:
                             result = api_propose_structure(active_id, updated)
@@ -836,6 +945,87 @@ elif page == "Validation View":
                             )
                         except Exception as exc:
                             st.error(f"提案の送信に失敗しました: {exc}")
+
+                    # ── パターンプレビュー表示 ──────────────────────────────
+                    _preview_data = st.session_state.pattern_preview.get(active_id)
+                    if _preview_data:
+                        st.divider()
+                        st.markdown("### ✨ パターン抽出プレビュー")
+                        st.caption(
+                            "抽出された抽象化パターンを確認・編集できます。"
+                            "内容に納得したら「🌍 正式登録」ボタンで共有知として登録してください。"
+                        )
+                        with st.expander("パターンプレビュー", expanded=True):
+                            _pv_name = st.text_input(
+                                "パターン名",
+                                value=_preview_data.get("name", ""),
+                                key="pv_name",
+                            )
+                            _pv_desc = st.text_area(
+                                "説明",
+                                value=_preview_data.get("description", ""),
+                                height=100,
+                                key="pv_desc",
+                            )
+                            _pv_vars_raw = _preview_data.get("variables_template", [])
+                            _pv_vars = st.text_area(
+                                "変数テンプレート (1行1変数)",
+                                value="\n".join(_pv_vars_raw),
+                                height=80,
+                                key="pv_vars",
+                            )
+                            _pv_rules_raw = _preview_data.get("structural_rules", [])
+                            _pv_rules = st.text_area(
+                                "構造ルール (1行1ルール)",
+                                value="\n".join(_pv_rules_raw),
+                                height=100,
+                                key="pv_rules",
+                            )
+
+                            _reg_col, _cancel_col = st.columns(2)
+                            with _reg_col:
+                                if st.button(
+                                    "🌍 このパターンをシステムに正式登録する",
+                                    use_container_width=True,
+                                    type="primary",
+                                    key="btn_register_pattern",
+                                ):
+                                    _edited_pattern = {
+                                        "pattern_id": _preview_data.get("pattern_id", ""),
+                                        "name": _pv_name,
+                                        "description": _pv_desc,
+                                        "variables_template": [
+                                            v.strip()
+                                            for v in _pv_vars.splitlines()
+                                            if v.strip()
+                                        ],
+                                        "structural_rules": [
+                                            r.strip()
+                                            for r in _pv_rules.splitlines()
+                                            if r.strip()
+                                        ],
+                                        "source_arxiv_id": _preview_data.get(
+                                            "source_arxiv_id", active_id
+                                        ),
+                                    }
+                                    try:
+                                        _reg_resp = api_register_pattern(_edited_pattern)
+                                        st.session_state.pattern_preview.pop(active_id, None)
+                                        st.toast(
+                                            f"パターンを正式登録しました (ID: {_reg_resp.get('pattern_id', '')[:8]}…)",
+                                            icon="🌍",
+                                        )
+                                        st.rerun()
+                                    except Exception as exc:
+                                        st.error(f"パターンの登録に失敗しました: {exc}")
+                            with _cancel_col:
+                                if st.button(
+                                    "❌ キャンセル",
+                                    use_container_width=True,
+                                    key="btn_cancel_pattern",
+                                ):
+                                    st.session_state.pattern_preview.pop(active_id, None)
+                                    st.rerun()
 
                 # ── Chat tab ──────────────────────────────────────────────────
                 with chat_tab:


### PR DESCRIPTION
## Summary
This PR introduces a user draft system for paper structures and refactors the pattern extraction workflow to support a preview-then-register pattern. Users can now save private drafts of paper structures to Neo4j, preview extracted patterns before registration, and explicitly register patterns to the shared knowledge base.

## Key Changes

### Backend (`backend/main.py`)
- **Draft Management API**
  - Added `GET /api/draft/{arxiv_id}` to retrieve user's private draft from Neo4j
  - Added `PUT /api/draft/{arxiv_id}` to save/upsert user's private draft in Neo4j
  - Extended `ExtractRequest` model with `is_draft` and `user_id` fields to support draft-mode extraction

- **Pattern Extraction Refactoring**
  - Replaced async pattern extraction job with synchronous `POST /api/patterns/extract/{arxiv_id}` endpoint that returns pattern preview without persisting to DB
  - Added `POST /api/patterns/register` endpoint to explicitly register confirmed patterns to Qdrant/Neo4j
  - Split `_run_pattern_extraction_task` into `_run_pattern_evaluation_task` for background batch evaluation only
  - Added `PatternRegisterRequest` and `PatternRegisterResponse` models

- **Extraction Task Enhancement**
  - Modified `_run_extraction_task` to support draft mode: when `is_draft=True`, saves structure to Neo4j as user draft instead of MinIO
  - Added logging to distinguish between draft and canonical extraction modes

### Frontend (`frontend/app.py`)
- **Session State Management**
  - Added `draft_papers` to track which papers have user drafts
  - Added `pattern_preview` to store pattern extraction preview results

- **Draft-First Loading Logic**
  - Modified structure loading to prioritize user drafts over canonical MinIO structures
  - Auto-loads draft when paper extraction completes if draft exists

- **UI Enhancements**
  - Added visual badges to distinguish between "📝 あなたの未公開ドラフト" (user draft) and "🏛️ システム正規テンプレート" (canonical)
  - Split action buttons: "Re-Extract" now saves as draft; added separate "💾 Save edits" button for manual draft saves
  - Added pattern preview section with editable fields (name, description, variables, rules)
  - Pattern registration now requires explicit user confirmation with "🌍 このパターンをシステムに正式登録する" button

- **API Integration**
  - Added `api_get_draft()`, `api_save_draft()`, and `api_register_pattern()` helper functions
  - Updated `api_extract()` to pass `is_draft` and `user_id` parameters
  - Changed `api_extract_pattern()` to synchronous with 120s timeout for preview generation

## Implementation Details
- Draft structures are stored as JSON strings in Neo4j with `HAS_DRAFT` relationships between User and Draft nodes
- Pattern preview is generated synchronously without database persistence, allowing users to review and edit before registration
- Background batch evaluation is triggered only after explicit pattern registration, reducing unnecessary processing
- Draft mode extraction uses the same text extraction and structure analysis pipeline but routes results to Neo4j instead of MinIO

https://claude.ai/code/session_01Qdp4MMzPQ625u3T7cbNjZb