### PR TITLE
Add MetaWeave-SMILES DSL field to abstract structure

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -448,6 +448,7 @@ def _empty_structure(paper_id: str) -> dict:
         "methodology": {"approach": "", "techniques": []},
         "constraints": {"assumptions": [], "limitations": []},
         "abstract_structure": {
+            "smiles_dsl": "",
             "variables": [],
             "edges": [],
         },
@@ -856,6 +857,11 @@ elif page == "Validation View":
 
                         with tab3:
                             st.markdown("#### Abstract Structure")
+                            smiles_dsl = st.text_area(
+                                "MetaWeave-SMILES DSL",
+                                value=s["abstract_structure"].get("smiles_dsl", ""),
+                                height=80,
+                            )
                             variables = st.text_area(
                                 "Variables (one per line)",
                                 value="\n".join(s["abstract_structure"]["variables"]),
@@ -914,6 +920,7 @@ elif page == "Validation View":
                                 ],
                             },
                             "abstract_structure": {
+                                "smiles_dsl": smiles_dsl,
                                 "variables": [
                                     v.strip() for v in variables.splitlines() if v.strip()
                                 ],


### PR DESCRIPTION
## Summary
This PR adds support for a MetaWeave-SMILES DSL (Domain Specific Language) field to the abstract structure section of papers. This allows users to input and store DSL code that describes the abstract structure of research papers.

## Key Changes
- Added `smiles_dsl` field to the abstract structure initialization in `_empty_structure()` function
- Added a new text area input field in the UI for users to enter MetaWeave-SMILES DSL code
- Integrated the DSL input into the data persistence layer so it's saved alongside other abstract structure fields (variables and edges)

## Implementation Details
- The `smiles_dsl` field is initialized as an empty string in the structure template
- A text area widget with 80px height is provided for DSL input, with support for multi-line content
- The field is retrieved from saved data using `.get("smiles_dsl", "")` to maintain backward compatibility with existing records
- The DSL value is properly captured and stored in the abstract_structure dictionary during save operations

https://claude.ai/code/session_011BqFV3y84HtdjgJDCv3cFM