### PR TITLE
Add Cross-Domain Search page with NL-to-DSL conversion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -527,6 +527,111 @@ def search_structure(body: StructureSearchRequest) -> StructureSearchResponse:
     return StructureSearchResponse(hits=hits, total=len(hits))
 
 
+# ---------------------------------------------------------------------------
+# Natural Language → SMILES DSL conversion
+# ---------------------------------------------------------------------------
+
+class NlToDslRequest(BaseModel):
+    """Request body for POST /api/search/nl-to-dsl."""
+
+    natural_language_query: str
+
+
+class NlToDslResponse(BaseModel):
+    """Response for POST /api/search/nl-to-dsl."""
+
+    query_dsl_regex: str
+    explanation: str
+
+
+_NL_TO_DSL_PROMPT = """\
+あなたは MetaWeave の構造検索アシスタントです。
+ユーザーが自然言語で述べた課題・疑問を、MetaWeave-SMILES DSL の正規表現パターンに変換してください。
+
+## MetaWeave-SMILES DSL の書式
+- 変数: [略号:概念名:オントロジータイプ]  例: [a:Agent:Organization]
+- 因果辺: -[relation:polarity]->  例: -[cause:+]->
+- オントロジータイプ: Agent, Resource, Event, Purpose, InstitutionalAgent, IntentionalMoment
+
+## 出力ルール
+1. Qdrant の payload テキスト検索 (部分一致) に適した正規表現を生成する
+2. ワイルドカード (.*) を活用し、具体的なドメイン用語ではなく抽象的な構造パターンを捉える
+3. 複数のパターンが考えられる場合は、最も包括的な1つを選ぶ
+4. 出力は JSON 形式で返す: {"query_dsl_regex": "<正規表現>", "explanation": "<日本語での簡潔な説明>"}
+
+## 例
+入力: "限られた資源を複数の主体が奪い合う問題"
+出力: {"query_dsl_regex": "\\\\[.*:Agent\\\\].*-\\\\[.*compete.*\\\\]->.*\\\\[.*:Resource\\\\]", "explanation": "複数のエージェントがリソースを巡って競合する構造パターン"}
+
+入力: "技術革新が既存のビジネスモデルを破壊する現象"
+出力: {"query_dsl_regex": "\\\\[.*:Event\\\\].*-\\\\[.*destroy.*:-\\\\]->.*\\\\[.*:Resource\\\\]", "explanation": "イベント（技術革新）がリソース（ビジネスモデル）を負の方向に変化させる構造"}
+"""
+
+
+@app.post("/api/search/nl-to-dsl", response_model=NlToDslResponse)
+def nl_to_dsl(body: NlToDslRequest) -> NlToDslResponse:
+    """自然言語クエリを MetaWeave-SMILES DSL 正規表現に変換する。
+
+    LLM を使い、ユーザーの課題記述を Qdrant ペイロード検索互換の
+    DSL 正規表現に変換して返す。
+    """
+    if not body.natural_language_query.strip():
+        raise HTTPException(status_code=400, detail="natural_language_query is required.")
+
+    client = get_client()
+    settings = get_settings()
+
+    try:
+        response = client.chat.completions.create(
+            model=settings.analysis_model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        f"{_NL_TO_DSL_PROMPT}\n\n"
+                        f"入力: \"{body.natural_language_query}\"\n"
+                        "出力:"
+                    ),
+                },
+            ],
+        )
+        raw = response.choices[0].message.content.strip()
+
+        # JSON 部分を抽出（コードブロック記法に対応）
+        if "```" in raw:
+            # ```json ... ``` or ``` ... ```
+            import re as _re
+            _match = _re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, _re.DOTALL)
+            if _match:
+                raw = _match.group(1)
+        elif raw.startswith("{"):
+            pass  # already JSON
+        else:
+            # 行内の最初の { ... } を抜き出す
+            import re as _re
+            _match = _re.search(r"\{.*\}", raw, _re.DOTALL)
+            if _match:
+                raw = _match.group(0)
+
+        parsed = json.loads(raw)
+        return NlToDslResponse(
+            query_dsl_regex=parsed.get("query_dsl_regex", ""),
+            explanation=parsed.get("explanation", ""),
+        )
+    except json.JSONDecodeError:
+        logger.warning("NL-to-DSL: LLM response was not valid JSON: %s", raw)
+        # フォールバック: raw テキストをそのまま regex として返す
+        return NlToDslResponse(
+            query_dsl_regex=raw[:500] if raw else "",
+            explanation="LLM出力のJSON解析に失敗しました。手動で調整してください。",
+        )
+    except Exception as exc:
+        logger.exception("NL-to-DSL conversion failed")
+        raise HTTPException(
+            status_code=500, detail=f"NL-to-DSL conversion failed: {exc}"
+        ) from exc
+
+
 @app.post("/api/fetch", response_model=FetchResponse)
 def fetch(body: FetchRequest) -> FetchResponse:
     """Download the PDF for the specified paper and store it in MinIO."""

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -63,6 +63,17 @@ if "draft_papers" not in st.session_state:
 # パターンプレビュー結果: arxiv_id -> pattern dict
 if "pattern_preview" not in st.session_state:
     st.session_state.pattern_preview: dict[str, dict] = {}
+# Cross-Domain Search 用の状態
+if "xd_query" not in st.session_state:
+    st.session_state.xd_query: str = ""
+if "xd_dsl_regex" not in st.session_state:
+    st.session_state.xd_dsl_regex: str = ""
+if "xd_explanation" not in st.session_state:
+    st.session_state.xd_explanation: str = ""
+if "xd_results" not in st.session_state:
+    st.session_state.xd_results: list[dict] = []
+if "xd_searched" not in st.session_state:
+    st.session_state.xd_searched: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +347,34 @@ def api_save_draft(arxiv_id: str, structure: dict) -> dict:
     return resp.json()
 
 
+def api_nl_to_dsl(natural_language_query: str) -> dict:
+    """POST /api/search/nl-to-dsl — convert natural language to SMILES DSL regex."""
+    resp = requests.post(
+        f"{BACKEND_URL}/api/search/nl-to-dsl",
+        json={"natural_language_query": natural_language_query},
+        headers=_auth_headers(),
+        timeout=60,
+    )
+    resp.raise_for_status()
+    return resp.json()  # {query_dsl_regex, explanation}
+
+
+def api_search_structure(query_dsl_regex: str, query_text: str, top_k: int = 10) -> dict:
+    """POST /api/search/structure — FANNS hybrid search."""
+    resp = requests.post(
+        f"{BACKEND_URL}/api/search/structure",
+        json={
+            "query_dsl_regex": query_dsl_regex,
+            "query_text": query_text,
+            "top_k": top_k,
+        },
+        headers=_auth_headers(),
+        timeout=60,
+    )
+    resp.raise_for_status()
+    return resp.json()  # {hits: [...], total: int}
+
+
 def api_register_pattern(pattern: dict) -> dict:
     """POST /api/patterns/register — register a confirmed pattern to Qdrant/Neo4j."""
     resp = requests.post(
@@ -494,7 +533,7 @@ with _user_col:
 with st.sidebar:
     st.markdown("## MetaWeave v1")
     st.caption(f"👤 {st.session_state.username}")
-    page = st.radio("Navigation", ["Harvester Dashboard", "Validation View", "Pattern Library"])
+    page = st.radio("Navigation", ["Harvester Dashboard", "Validation View", "Pattern Library", "Cross-Domain Search"])
 
     if page == "Validation View":
         st.divider()
@@ -1242,3 +1281,189 @@ elif page == "Pattern Library":
                         )
                     except Exception:
                         st.caption("情報の取得に失敗しました。")
+
+# =========================================================================
+# Page D — Cross-Domain Search (分野横断構造検索)
+# =========================================================================
+elif page == "Cross-Domain Search":
+    st.header("Cross-Domain Search")
+    st.caption(
+        "自然言語で課題を入力すると、構造的に類似した異分野の論文を発見できます。"
+        " MetaWeave-SMILES DSL ベースの FANNS ハイブリッド検索を利用しています。"
+    )
+
+    # ── Step 1: 自然言語入力 ─────────────────────────────────────────────
+    st.markdown("### 1. 課題を入力")
+    xd_nl_input = st.text_area(
+        "あなたの課題・疑問を自然言語で記述してください",
+        value=st.session_state.xd_query,
+        height=120,
+        placeholder="例: 限られた資源を複数の主体が奪い合う問題を解決したい",
+        key="xd_nl_input",
+    )
+
+    _convert_col, _clear_col, _ = st.columns([1, 1, 4])
+    with _convert_col:
+        xd_convert_btn = st.button(
+            "DSL に変換",
+            use_container_width=True,
+            type="primary",
+            key="btn_xd_convert",
+        )
+    with _clear_col:
+        xd_clear_btn = st.button(
+            "クリア",
+            use_container_width=True,
+            key="btn_xd_clear",
+        )
+
+    if xd_clear_btn:
+        st.session_state.xd_query = ""
+        st.session_state.xd_dsl_regex = ""
+        st.session_state.xd_explanation = ""
+        st.session_state.xd_results = []
+        st.session_state.xd_searched = False
+        st.rerun()
+
+    if xd_convert_btn and xd_nl_input.strip():
+        st.session_state.xd_query = xd_nl_input.strip()
+        with st.spinner("LLM で構造パターン (DSL) に変換中…"):
+            try:
+                _dsl_resp = api_nl_to_dsl(xd_nl_input.strip())
+                st.session_state.xd_dsl_regex = _dsl_resp.get("query_dsl_regex", "")
+                st.session_state.xd_explanation = _dsl_resp.get("explanation", "")
+                st.session_state.xd_searched = False
+                st.rerun()
+            except Exception as exc:
+                st.error(f"DSL 変換に失敗しました: {exc}")
+
+    # ── Step 2: DSL 編集フィールド ───────────────────────────────────────
+    if st.session_state.xd_dsl_regex or st.session_state.xd_explanation:
+        st.divider()
+        st.markdown("### 2. DSL パターンを確認・編集")
+
+        if st.session_state.xd_explanation:
+            st.info(f"**LLM の解釈:** {st.session_state.xd_explanation}")
+
+        xd_dsl_edited = st.text_area(
+            "MetaWeave-SMILES DSL 正規表現 (編集可能)",
+            value=st.session_state.xd_dsl_regex,
+            height=80,
+            key="xd_dsl_edit",
+        )
+
+        xd_query_text = st.text_input(
+            "補助テキストクエリ (意味的類似度検索、任意)",
+            value=st.session_state.xd_query,
+            key="xd_query_text",
+        )
+
+        _top_k_col, _search_col, _ = st.columns([1, 1, 4])
+        with _top_k_col:
+            xd_top_k = st.number_input(
+                "最大件数",
+                min_value=1,
+                max_value=50,
+                value=10,
+                key="xd_top_k",
+            )
+        with _search_col:
+            st.markdown("")  # spacer for alignment
+            xd_search_btn = st.button(
+                "構造検索を実行",
+                use_container_width=True,
+                type="primary",
+                key="btn_xd_search",
+            )
+
+        if xd_search_btn:
+            if not xd_dsl_edited.strip() and not xd_query_text.strip():
+                st.warning("DSL パターンまたはテキストクエリのいずれかを入力してください。")
+            else:
+                st.session_state.xd_dsl_regex = xd_dsl_edited.strip()
+                with st.spinner("FANNS ハイブリッド検索を実行中…"):
+                    try:
+                        _search_resp = api_search_structure(
+                            query_dsl_regex=xd_dsl_edited.strip(),
+                            query_text=xd_query_text.strip(),
+                            top_k=int(xd_top_k),
+                        )
+                        st.session_state.xd_results = _search_resp.get("hits", [])
+                        st.session_state.xd_searched = True
+                        st.rerun()
+                    except Exception as exc:
+                        st.error(f"構造検索に失敗しました: {exc}")
+
+    # ── Step 3: 検索結果表示 ─────────────────────────────────────────────
+    if st.session_state.xd_searched:
+        st.divider()
+        st.markdown("### 3. 検索結果")
+
+        _hits = st.session_state.xd_results
+        if not _hits:
+            st.warning(
+                "構造的に一致する論文が見つかりませんでした。\n\n"
+                "**ヒント:** DSL パターンのワイルドカード (`.*`) を増やして"
+                "抽象度を上げるか、補助テキストクエリを追加してみてください。"
+            )
+        else:
+            st.success(f"{len(_hits)} 件の構造的に類似した論文が見つかりました。")
+
+            for _hi, _hit in enumerate(_hits):
+                _h_arxiv = _hit.get("arxiv_id", "")
+                _h_score = _hit.get("score", 0.0)
+                _h_text = _hit.get("text", "")
+                _h_smiles = _hit.get("smiles_dsl", "")
+                _h_vars = _hit.get("variables", [])
+
+                with st.container(border=True):
+                    _h_left, _h_right = st.columns([4, 1])
+
+                    with _h_left:
+                        # タイトルを取得（メタデータがあれば使う、なければarXiv ID）
+                        _h_title = (
+                            st.session_state.paper_metadata.get(_h_arxiv, {}).get("title")
+                            or st.session_state.structures.get(_h_arxiv, {}).get("title")
+                            or _h_arxiv
+                        )
+                        st.markdown(f"**{_h_title}**")
+                        st.caption(f"arXiv ID: `{_h_arxiv}`")
+
+                        if _h_text:
+                            _preview_text = _h_text[:300] + ("…" if len(_h_text) > 300 else "")
+                            st.markdown(f"> {_preview_text}")
+
+                        if _h_smiles:
+                            st.code(_h_smiles, language=None)
+
+                        if _h_vars:
+                            st.markdown(
+                                "**Variables:** "
+                                + ", ".join(f"`{v}`" for v in _h_vars)
+                            )
+
+                    with _h_right:
+                        st.metric("Score", f"{_h_score:.3f}")
+
+                        # Validation View へのナビゲーション
+                        if st.button(
+                            "詳細を見る",
+                            key=f"xd_detail_{_hi}",
+                            use_container_width=True,
+                        ):
+                            st.session_state.active_paper_id = _h_arxiv
+                            # stored_papers に登録されていなければ追加
+                            if _h_arxiv not in st.session_state.stored_papers:
+                                try:
+                                    _remote_papers = api_list_papers()
+                                    for _rp in _remote_papers:
+                                        _rp_id = _rp.rsplit("/", 1)[-1].replace(".pdf", "")
+                                        if _rp_id == _h_arxiv:
+                                            st.session_state.stored_papers[_h_arxiv] = _rp
+                                            break
+                                except Exception:
+                                    pass
+                            st.info(
+                                f"サイドバーの Navigation で **Validation View** を選択し、"
+                                f"論文 `{_h_arxiv}` の詳細を確認してください。"
+                            )


### PR DESCRIPTION
## Summary
This PR introduces a new "Cross-Domain Search" page to MetaWeave that enables users to discover structurally similar papers across different domains using natural language queries. The feature leverages LLM-powered conversion from natural language to MetaWeave-SMILES DSL patterns, combined with FANNS hybrid search.

## Key Changes

### Frontend (frontend/app.py)
- Added session state variables for Cross-Domain Search workflow (`xd_query`, `xd_dsl_regex`, `xd_explanation`, `xd_results`, `xd_searched`)
- Implemented two new API wrapper functions:
  - `api_nl_to_dsl()`: Converts natural language queries to SMILES DSL regex patterns
  - `api_search_structure()`: Executes FANNS hybrid search with DSL patterns and optional text queries
- Added "Cross-Domain Search" navigation option to sidebar
- Implemented complete Cross-Domain Search page (Page D) with three-step workflow:
  1. Natural language input with DSL conversion button
  2. DSL pattern editing and review with LLM explanation
  3. Search results display with score metrics and navigation to Validation View

### Backend (backend/main.py)
- Added `NlToDslRequest` and `NlToDslResponse` Pydantic models
- Implemented `POST /api/search/nl-to-dsl` endpoint that:
  - Uses LLM to convert natural language queries to MetaWeave-SMILES DSL regex patterns
  - Includes comprehensive system prompt with DSL syntax rules and examples
  - Handles JSON parsing from LLM responses with fallback for malformed output
  - Returns both the generated regex pattern and an explanation of the interpretation

## Notable Implementation Details
- The NL-to-DSL conversion uses a detailed prompt that teaches the LLM about MetaWeave-SMILES DSL syntax, ontology types (Agent, Resource, Event, Purpose, etc.), and relation patterns
- The frontend supports iterative refinement: users can edit the generated DSL pattern before executing the search
- Search results display includes arxiv ID, score, text preview, DSL pattern, and variables extracted from matches
- Results include a "詳細を見る" (View Details) button that navigates to Validation View for deeper analysis
- Graceful error handling with user-friendly Japanese error messages and hints for improving search results

https://claude.ai/code/session_01SnowQKGBHxFdkHgRJjEVTn