### PR TITLE
Expand MetaWeave skill documentation with architecture and FANNS details

### DIFF
--- a/.claude/skills/metaweave-dev/SKILL.md
+++ b/.claude/skills/metaweave-dev/SKILL.md
@@ -6,10 +6,83 @@ allowed-tools: Bash(python3 *)
 
 # MetaWeave 開発・検証エージェント
 
+## アーキテクチャ概要
+
+MetaWeave は「人類の問題構造マップ」を生成するメタ構造転写エンジンです。
+学問分野ごとの問題解決パターンを抽出し、異分野へ転写（Structural Isomorphism）します。
+
+### 技術スタック
+- **バックエンド**: FastAPI (Python 3.11+)
+- **フロントエンド**: Streamlit
+- **グラフDB**: Neo4j（論文・パターン間の構造的同型性エッジを管理）
+- **ベクトルDB**: Qdrant（Embedding 保存、FANNS ハイブリッド検索）
+- **オブジェクトストレージ**: MinIO（PDF・抽出済み構造 JSON の永続化）
+- **LLM**: OpenAI (gpt-5.2 等の Reasoning モデルを優先)
+- **PDF 解析**: GROBID（TEI XML 経由の論理セクション抽出）
+
+### コアモジュールと責務一覧
+
+| ファイル | 責務 |
+|---|---|
+| `backend/metaweave/extractor.py` | PDF→GROBID→TEI XML→論理チャンク→仮説検証型 LLM 抽出→`PaperStructure` 生成。Diff ベースの提案マージ（Gateway 層）。抽象化パターン抽出（Public 層）。 |
+| `backend/metaweave/chat.py` | RAG ベースのチャット応答。Qdrant でチャンクを類似度検索し、MinIO から `PaperStructure` をロードして LLM にコンテキストとして渡す。 |
+| `backend/metaweave/embedder.py` | Qdrant への Embedding 保存・検索。`papers` / `patterns` コレクション管理。FANNS ハイブリッド検索（Pre-filtering + ベクトル検索）の実装。 |
+| `backend/metaweave/batch.py` | パターン登録時の非同期バッチ評価。Qdrant で候補論文を検索→LLM で構造的同型性を評価→Neo4j に `MATCHES_PATTERN` エッジを保存。 |
+| `backend/metaweave/llm.py` | OpenAI クライアントファクトリ (`get_client` / `get_settings`)。Missing Link Suggestion の LLM プロンプト生成 (`generate_missing_link_suggestions`)。 |
+| `backend/metaweave/schema.py` | Pydantic 正典スキーマ。`PaperStructure`, `AbstractionPattern`, `PatternMatch`, `FieldDiff`, `MergeResult`, `MissingLinkSuggestion`, `FieldSuggestion` 等。 |
+| `backend/metaweave/harvester.py` | arXiv API 検索・PDF ダウンロード。商用出版社の検知・除外ロジックを内蔵。 |
+| `backend/metaweave/storage.py` | MinIO ラッパー (`StorageManager`)。バケット管理・PDF アップロード・署名付き URL 生成。 |
+| `backend/metaweave/db.py` | Neo4j ドライバのシングルトン管理。 |
+| `frontend/app.py` | Streamlit UI。論文検索・構造ビュー・チャット・Cross-Domain Search・パターン管理画面。 |
+
+---
+
+## 抽出エンジン（GROBID 統合）
+
+従来の PyMuPDF による盲目的なテキスト分割から、**GROBID の TEI XML パースを利用した論理セクション単位の抽出**へ進化しました。
+
+**処理フロー** (`extractor.py`):
+1. PDF バイナリを GROBID API (`/api/processFulltextDocument`) に送信し TEI XML を取得
+2. `parse_tei_to_logical_chunks()` で XML から `Abstract` / `Body` の各 `<div>` を論理チャンクとして抽出
+3. **References / Acknowledgments は正規表現 (`_EXCLUDED_HEADINGS`) で除外**（ノイズ排除）
+4. 8,000 文字超のセクションはセンテンス境界でフォールバック分割
+5. GROBID 未起動時は PyMuPDF へ自動フォールバック
+
+**仮説検証型の逐次精錬**:
+1. 最初のチャンク（Abstract 等）から `_generate_hypothesis()` で初期仮説ドラフトを生成
+2. 後続チャンクで `_refine_with_chunk()` により `_AnalysisState` を逐次更新（confirmed / revised / new_info / pending）
+3. `_finalize_structure()` で蓄積された状態から最終 `PaperStructure` を Structured Output で生成
+
+**Embedding の並行実行**: 抽出と並行して `ThreadPoolExecutor` で Qdrant への Embedding 保存を実行（最大 90 秒待機）。
+
+---
+
+## LLM Gateway（Diff ベースの査読）
+
+ユーザーからの構造変更提案をレビューする際、全体を LLM に渡すのではなく **Python 側で `PaperStructure` の差分（Diff）を計算し、変更フィールドのみを LLM に評価・マージさせる**堅牢な設計です。
+
+**処理フロー** (`extractor.py: evaluate_and_merge_proposals()`):
+1. `compute_structure_diff()` で `base` と `proposed` の `PaperStructure` を再帰比較し `FieldDiff` リストを生成
+2. 差分がなければ早期リターン（LLM 呼び出しなし）
+3. 差分フィールドのみを LLM に送信 → 各フィールドごとに `accept` / `reject` を判定
+4. `accept` された変更のみを `base` 構造にマージ → 未変更フィールドのハルシネーション破損を防止
+5. 結果を `MergeResult`（`merged_structure` + `evaluation_reasoning`）として返却
+
+**関連スキーマ** (`schema.py`): `FieldDiff`, `MergeResult`, `StructureProposal`
+
+---
+
+## Reasoning モデルの制約
+
+OpenAI の o1 / o3-mini / gpt-5.2 等の Reasoning モデルには以下の制約があり、コード全体で遵守しています:
+- `system` ロールは使用不可 → `user` ロールのみで送信
+- `temperature` / `max_tokens` は指定しない（`max_completion_tokens` のみ許可）
+
+---
+
 ## 1. 論文の強制抽出・再評価 (`/metaweave-dev extract <arxiv_id>`)
-`backend/metaweave/extractor.py` のロジックを用いて構造抽出を実行し、AnalysisStateの遷移ログを確認します。
+`backend/metaweave/extractor.py` のロジックを用いて構造抽出を実行し、AnalysisState の遷移ログを確認します。
 
 ## 2. 抽出プロンプトの最適化 (`/metaweave-dev tune-prompt`)
 - 現在の抽出結果と原文を比較し、因果関係（CausalEdge）や制約条件の抽出精度を向上させるためのプロンプト改善案を提示します。
-- **[New]** LLMが冗長なJSONではなく、指定された `MetaWeave-SMILES` のDSL構文（例: `[a:Agent:Toyota] -[causes:+]-> [r:Resource:Profit]`）を厳格に出力できているか、ダングリングエッジが発生していないか、また `OntologyType` が適切に分類されているかを重点的に検証します。
-
+- **[New]** LLM が冗長な JSON ではなく、指定された `MetaWeave-SMILES` の DSL 構文（例: `[a:Agent:Toyota] -[causes:+]-> [r:Resource:Profit]`）を厳格に出力できているか、ダングリングエッジが発生していないか、また `OntologyType` が適切に分類されているかを重点的に検証します。

--- a/.claude/skills/metaweave-pattern-dev/SKILL.md
+++ b/.claude/skills/metaweave-pattern-dev/SKILL.md
@@ -6,28 +6,94 @@ allowed-tools: Bash(python3 *)
 
 # MetaWeave Pattern Engine 開発支援スキル
 
-このスキルは、MetaWeaveの「Public層（抽象化パターンのテンプレート化と再評価）」のロジック検証をCLI上で高速に行うためのものです。
+このスキルは、MetaWeave の「Public 層（抽象化パターンのテンプレート化と再評価）」のロジック検証を CLI 上で高速に行うためのものです。
+
+## アーキテクチャ概要（パターン関連）
+
+### パターンライフサイクル
+
+```
+PaperStructure (approved)
+  → extract_abstraction_pattern() [extractor.py]
+    → AbstractionPattern (Evo-DKD: 変数テンプレート化)
+      → embed_and_store_pattern() [embedder.py] → Qdrant "patterns" コレクション
+      → run_pattern_evaluation_task() [batch.py]
+        → Qdrant で類似論文検索 → LLM で構造的同型性評価
+        → Neo4j に (:Paper)-[:MATCHES_PATTERN]->(:AbstractionPattern) エッジ保存
+      → generate_missing_link_suggestions() [llm.py]
+        → 構造的空白を AI が自律検知 → arXiv 検索クエリを提案
+```
+
+### 関連モジュールと責務
+
+| ファイル | パターン関連の責務 |
+|---|---|
+| `backend/metaweave/extractor.py` | `extract_abstraction_pattern()`: 承認済み `PaperStructure` から Evo-DKD アプローチで具体事象を変数（X, Y, Z）に置換し、分野横断の `AbstractionPattern` を LLM で抽出。 |
+| `backend/metaweave/embedder.py` | `embed_and_store_pattern()`: パターンを Qdrant `patterns` コレクションに Embedding 保存。`search_similar_papers()`: パターンに類似する過去論文を検索。`search_fanns_hybrid()`: FANNS ハイブリッド検索。 |
+| `backend/metaweave/batch.py` | `run_pattern_evaluation_task()`: 新パターン登録時の非同期バッチ。候補論文の `PaperStructure` を MinIO からロード→LLM で同型性評価→閾値 (0.6) 以上なら Neo4j にエッジ保存。 |
+| `backend/metaweave/llm.py` | `generate_missing_link_suggestions()`: パターンの構造的空白（適用可能だが未カバーの異分野）を AI が検知し、3〜5 件の分野別 arXiv 検索キーワードを提案。 |
+| `backend/metaweave/schema.py` | `AbstractionPattern`, `PatternMatch`, `MissingLinkSuggestion`, `FieldSuggestion` の Pydantic 正典スキーマ。 |
+| `backend/metaweave/db.py` | Neo4j ドライバ管理。`(:Paper)-[:MATCHES_PATTERN]->(:AbstractionPattern)` エッジの永続化先。 |
+
+---
+
+## 検索基盤（FANNS ハイブリッド検索）
+
+Qdrant の **Pre-filtering（`MatchText` による `smiles_dsl` ペイロードのテキストマッチ）とベクトル検索を組み合わせた真の構造検索**が `embedder.py: search_fanns_hybrid()` として実装完了しています。
+
+**FANNS が Pre-filtering を採用する理由**:
+意味（ベクトル）的に遠いが構造（SMILES DSL）が一致する異分野の論文を確実に発見するため。Post-filtering ではベクトル検索の時点で意味的に遠い論文が足切りされ、分野横断検索が成立しない。
+
+**処理フロー** (`embedder.py: search_fanns_hybrid()`):
+1. `query_text` を `text-embedding-3-large` でベクトル化
+2. `query_dsl_regex` が指定されている場合、`MatchText` フィルタで `smiles_dsl` ペイロードを DB 側で事前絞り込み
+3. フィルタ付きベクトル検索を実行（構造一致 → 意味的類似度ランキング）
+4. 同一 `arxiv_id` の重複排除（最高スコア保持）→ 上位 `top_k` 件を返却
+
+**API / UI**: FastAPI エンドポイントおよび Streamlit の Cross-Domain Search 画面から利用可能。
+
+---
+
+## パターン機能（Missing Link Suggestion）
+
+登録済みパターンの **「構造的空白（適用可能な異分野）」を AI が自律検知**し、ユーザーに arXiv 検索クエリを提案する機能です。
+
+**処理フロー** (`llm.py: generate_missing_link_suggestions()`):
+1. パターンのメタデータ（name, description, structural_rules, variables_template）と既知の適用分野リストを LLM に入力
+2. LLM が「このパターンが出現しうるが、まだカバーされていない学術分野」を 3〜5 件特定
+3. 各分野について、パターンが出現する具体的理由と arXiv 検索キーワード（2〜4 個）を生成
+4. 結果を `MissingLinkSuggestion`（`FieldSuggestion` のリスト）として返却
+
+**関連スキーマ** (`schema.py`): `MissingLinkSuggestion`, `FieldSuggestion`
+
+---
 
 ## 1. パターン抽出テスト (`/extract-pattern <arxiv_id>`)
-指定された `arxiv_id` の抽出済み構造（MinIO内の `extracted-structures`）を読み込み、`backend/metaweave/extractor.py` の `extract_abstraction_pattern` 関数を呼び出してテストします。
+指定された `arxiv_id` の抽出済み構造（MinIO 内の `extracted-structures`）を読み込み、`backend/metaweave/extractor.py` の `extract_abstraction_pattern` 関数を呼び出してテストします。
 **実行時の指示:**
-- 一時的なPythonスクリプトを生成し、対象論文から `AbstractionPattern` を抽出してください。
-- 出力されたJSONがPydanticモデル（変数テンプレート、構造ルールなど）に厳格に従っているか、またEvo-DKDの要件（汎用化されているか）を満たしているか検証し、結果をターミナルに整形して出力してください。
+- 一時的な Python スクリプトを生成し、対象論文から `AbstractionPattern` を抽出してください。
+- 出力された JSON が Pydantic モデル（変数テンプレート、構造ルールなど）に厳格に従っているか、また Evo-DKD の要件（汎用化されているか）を満たしているか検証し、結果をターミナルに整形して出力してください。
 
 ## 2. FANNS ハイブリッド検索テスト (`/test-fanns-search <query_regex> <query_text>`)
-Qdrantのペイロードに保存された `smiles_dsl` に対する正規表現フィルタと、ベクトル類似度検索を組み合わせたハイブリッド検索（FANNS）のテストを実行します。
+`backend/metaweave/embedder.py` の `search_fanns_hybrid()` を呼び出し、Qdrant の `smiles_dsl` ペイロードに対するテキストフィルタとベクトル類似度検索を組み合わせたハイブリッド検索（FANNS）のテストを実行します。
 **実行時の指示:**
-- 一時スクリプトを作成し、まず `query_regex` を用いてQdrantの `smiles_dsl` ペイロードを事前フィルタリング（Pre-filtering）してください。
-- その後、フィルタを通過したID（Candidate Set）に対して `query_text` のベクトル検索を行い、トップ5件を出力してください。構造的条件と意味的条件が両立できているか確認してください。
+- 一時スクリプトを作成し、`search_fanns_hybrid(query_dsl_regex=query_regex, query_text=query_text)` を直接呼び出してください。
+- トップ 5 件を出力し、構造的条件（SMILES DSL マッチ）と意味的条件（ベクトル類似度）が両立できているか確認してください。
 
 ## 3. 再評価バッチの強制実行 (`/run-pattern-batch <pattern_id>`)
-`backend/main.py` (または `batch.py`) の `_run_pattern_evaluation_task` を強制的に同期実行します。
+`backend/metaweave/batch.py` の `run_pattern_evaluation_task` を強制的に同期実行します。
 **実行時の指示:**
-- スクリプト経由で対象パターンのバッチ評価処理を走らせ、LLMが「過去の論文がこのパターンと同型（Isomorphic）であるか」をどう判断したか（`PatternMatch` の生成と confidence_score）のログを出力してください。
-- Neo4jに `(:Paper)-[:MATCHES_PATTERN]->(:AbstractionPattern)` のエッジが正しく張られたかをCypherクエリで確認してください。
+- スクリプト経由で対象パターンのバッチ評価処理を走らせ、LLM が「過去の論文がこのパターンと同型（Isomorphic）であるか」をどう判断したか（`PatternMatch` の生成と confidence_score）のログを出力してください。
+- Neo4j に `(:Paper)-[:MATCHES_PATTERN]->(:AbstractionPattern)` のエッジが正しく張られたかを Cypher クエリで確認してください。
+
+## 4. Missing Link Suggestion テスト (`/test-missing-link <pattern_id>`)
+`backend/metaweave/llm.py` の `generate_missing_link_suggestions()` を呼び出し、指定パターンの構造的空白検知をテストします。
+**実行時の指示:**
+- 対象パターンの情報を MinIO / Qdrant からロードし、`generate_missing_link_suggestions()` に渡してください。
+- 出力された `MissingLinkSuggestion` の各 `FieldSuggestion` について、提案された分野・キーワードが妥当かどうかを確認してください。
 
 ## 開発上の注意点（エージェント向け）
-- OpenAI APIを使用するため、`.env` の読み込みを確実に行ってください。
-- Qdrantのローカル接続（メモリモードまたはDockerコンテナ）の設定に注意し、接続エラー時は詳細なログを提示してください。
+- OpenAI API を使用するため、`.env` の読み込みを確実に行ってください。
+- Qdrant のローカル接続（メモリモードまたは Docker コンテナ）の設定に注意し、接続エラー時は詳細なログを提示してください。
 - 常に `backend/metaweave/schema.py` の正典モデルをインポートして型検証を行ってください。
-
+- Reasoning モデル（o1 / o3-mini / gpt-5.2）使用時は `system` ロール不可、`temperature` / `max_tokens` 指定不可の制約を遵守してください。


### PR DESCRIPTION
## Summary
This PR significantly expands the MetaWeave development skill documentation to provide comprehensive architectural context, module responsibilities, and implementation details for the pattern engine and search infrastructure.

## Key Changes

### metaweave-pattern-dev/SKILL.md
- **Added Architecture Overview section** with pattern lifecycle diagram showing the flow from `PaperStructure` through pattern extraction, embedding, evaluation, and missing link suggestion
- **Added Module Responsibility Table** documenting the role of each backend module (`extractor.py`, `embedder.py`, `batch.py`, `llm.py`, `schema.py`, `db.py`) in the pattern pipeline
- **Added FANNS Hybrid Search section** explaining the Pre-filtering + vector search approach and why it's necessary for cross-domain discovery (semantic distance vs. structural matching)
- **Added Missing Link Suggestion section** describing how the system autonomously detects structural gaps and proposes arXiv search queries
- **Added new test command** `/test-missing-link <pattern_id>` for validating the missing link suggestion feature
- **Updated existing test commands** with more precise implementation details (e.g., direct `search_fanns_hybrid()` calls instead of manual pre-filtering)
- **Added Reasoning model constraints** note about o1/o3-mini/gpt-5.2 limitations (no system role, no temperature/max_tokens)
- **Improved formatting** with consistent spacing and terminology (e.g., "CLI" → "CLI", "Python" → "Python")

### metaweave-dev/SKILL.md
- **Added comprehensive Architecture Overview** section covering the full MetaWeave tech stack (FastAPI, Streamlit, Neo4j, Qdrant, MinIO, OpenAI, GROBID)
- **Added Core Modules Table** with detailed responsibility descriptions for all backend components and the Streamlit frontend
- **Added Extraction Engine section** explaining GROBID TEI XML integration, logical chunk extraction, hypothesis-verification refinement loop, and PyMuPDF fallback
- **Added LLM Gateway section** documenting the Diff-based review approach for structure change proposals to prevent hallucination-induced corruption
- **Added Reasoning Model Constraints section** with explicit guidance on o1/o3-mini/gpt-5.2 API limitations
- **Improved formatting** with consistent terminology and spacing throughout

## Notable Implementation Details
- Both skills now document the **Pre-filtering strategy** in FANNS: structural matching (SMILES DSL regex) happens before semantic ranking to ensure cross-domain papers aren't filtered out by vector similarity alone
- The pattern lifecycle is now explicitly visualized with a flow diagram showing Neo4j edge persistence and Qdrant collection management
- The extraction engine's **hypothesis-verification loop** is documented with state transitions (confirmed/revised/new_info/pending)
- The **Diff-based merge strategy** is explained as a safeguard against LLM hallucination when reviewing user-proposed structure changes

https://claude.ai/code/session_01ApoqGwxTqr3nK18U7b215R