### PR TITLE
Add license field to PaperStructure schema

### DIFF
--- a/backend/metaweave/schema.py
+++ b/backend/metaweave/schema.py
@@ -82,6 +82,7 @@ class PaperStructure(BaseModel):
     methodology: Methodology = Field(default_factory=Methodology)
     constraints: Constraints = Field(default_factory=Constraints)
     abstract_structure: AbstractStructure = Field(default_factory=AbstractStructure)
+    license: str = Field(default="", description="The license of the paper (e.g., from arXiv metadata)")
     review_status: ReviewStatus = Field(default=ReviewStatus.PENDING)
     reviewer_notes: str = Field(default="")
 


### PR DESCRIPTION
## Summary
Added a new `license` field to the `PaperStructure` model to capture and store paper license information from metadata sources like arXiv.

## Key Changes
- Added `license: str` field to `PaperStructure` class with an empty string default value
- Field includes a description indicating it stores license information from arXiv metadata
- Field is positioned before the `review_status` field in the schema

## Implementation Details
- The license field is optional with a sensible default (empty string) to maintain backward compatibility
- The field description clarifies the intended use case (storing arXiv metadata licenses)
- This allows the system to preserve and track licensing information for papers during the analysis workflow

https://claude.ai/code/session_01FREa6ogc9uPpMM3sAxV1Fd