### PR TITLE
Add license field support to paper extraction pipeline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -141,6 +141,7 @@ class ExtractRequest(BaseModel):
     is_draft: bool = False
     user_id: str | None = None
     skip_embedding: bool = False
+    license: str = ""
 
 
 class ExtractAccepted(BaseModel):
@@ -396,6 +397,7 @@ def _run_extraction_task(
     is_draft: bool = False,
     user_id: str | None = None,
     skip_embedding: bool = False,
+    license: str = "",
 ) -> None:
     """バックグラウンドで実行される抽出タスク。
 
@@ -425,6 +427,7 @@ def _run_extraction_task(
         text = ext.extract_text_from_pdf_bytes(pdf_bytes)
         structure = ext.extract_paper_structure(
             text, paper_id=arxiv_id, skip_embedding=skip_embedding, pdf_bytes=pdf_bytes,
+            license=license,
         )
 
         if is_draft and user_id:
@@ -705,6 +708,7 @@ def extract(body: ExtractRequest, background_tasks: BackgroundTasks) -> ExtractA
         is_draft=body.is_draft,
         user_id=body.user_id,
         skip_embedding=effective_skip_embedding,
+        license=body.license,
     )
     logger.info(
         "Extraction job queued for %s (is_draft=%s, skip_embedding=%s)",

--- a/backend/metaweave/extractor.py
+++ b/backend/metaweave/extractor.py
@@ -325,7 +325,7 @@ def _refine_with_chunk(state: _AnalysisState, chunk: str, chunk_idx: int) -> Non
     logger.debug("Chunk %d refined for state", chunk_idx)
 
 
-def _finalize_structure(state: _AnalysisState, paper_id: str) -> PaperStructure:
+def _finalize_structure(state: _AnalysisState, paper_id: str, license: str = "") -> PaperStructure:
     """蓄積された分析状態から最終的な PaperStructure を生成する。"""
     client = get_client()
     settings = get_settings()
@@ -373,7 +373,7 @@ def _finalize_structure(state: _AnalysisState, paper_id: str) -> PaperStructure:
         response_format=PaperStructure,
     )
     structure: PaperStructure = resp.choices[0].message.parsed
-    return structure.model_copy(update={"paper_id": paper_id})
+    return structure.model_copy(update={"paper_id": paper_id, "license": license})
 
 
 def _embed_and_store_chunks(chunks: list[str], paper_id: str) -> None:
@@ -399,6 +399,7 @@ def extract_paper_structure(
     paper_id: str = "",
     skip_embedding: bool = False,
     pdf_bytes: bytes | None = None,
+    license: str = "",
 ) -> PaperStructure:
     """仮説検証型の逐次処理で論文テキストから PaperStructure を抽出する。
 
@@ -465,7 +466,7 @@ def extract_paper_structure(
 
         # Step 3: 最終評価
         logger.info("Finalizing structure for %s", paper_id)
-        structure = _finalize_structure(state, paper_id)
+        structure = _finalize_structure(state, paper_id, license=license)
 
     finally:
         # Embedding の完了を待つ（最大 90 秒、失敗しても続行）

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -185,13 +185,16 @@ def api_list_papers() -> list[str]:
 
 
 def api_extract(
-    object_name: str, arxiv_id: str, is_draft: bool = False, user_id: str | None = None
+    object_name: str, arxiv_id: str, is_draft: bool = False, user_id: str | None = None,
+    license: str = "",
 ) -> dict:
     """POST /api/extract — submit async job, returns {arxiv_id, status: "pending"}."""
     payload: dict = {"object_name": object_name, "arxiv_id": arxiv_id}
     if is_draft:
         payload["is_draft"] = True
         payload["user_id"] = user_id
+    if license:
+        payload["license"] = license
     resp = requests.post(
         f"{BACKEND_URL}/api/extract",
         json=payload,
@@ -677,7 +680,7 @@ if page == "Harvester Dashboard":
                                 st.session_state.stored_papers[arxiv_id] = object_name
                                 st.session_state.paper_metadata[arxiv_id] = meta
                             # 非同期抽出ジョブをキュー登録（即時返答）
-                            api_extract(object_name, arxiv_id)
+                            api_extract(object_name, arxiv_id, license=meta.get("license", ""))
                             st.session_state.processing_papers[arxiv_id] = {
                                 "title": meta.get("title", arxiv_id),
                                 "object_name": object_name,
@@ -963,6 +966,7 @@ elif page == "Validation View":
                         updated: dict = {
                             "paper_id": active_id,
                             "title": s.get("title", ""),
+                            "license": s.get("license", ""),
                             "problem": {"background": bg, "problem": prob},
                             "hypothesis": {"statement": hyp_stmt, "rationale": hyp_rat},
                             "methodology": {


### PR DESCRIPTION
## Summary
This PR adds support for capturing and propagating license information through the paper extraction pipeline, from the frontend API through to the final paper structure.

## Key Changes
- **Frontend (`frontend/app.py`)**:
  - Added `license` parameter to `api_extract()` function
  - Pass license metadata from paper metadata to the extraction API call
  - Include license field in the updated paper structure dictionary

- **Backend Extractor (`backend/metaweave/extractor.py`)**:
  - Added `license` parameter to `extract_paper_structure()` function
  - Updated `_finalize_structure()` to accept and apply license to the final `PaperStructure`
  - License is now included in the model copy when creating the final structure

- **Backend API (`backend/main.py`)**:
  - Added `license` field to `ExtractRequest` model
  - Added `license` parameter to `_run_extraction_task()` function
  - Propagate license through the extraction task to `extract_paper_structure()`

## Implementation Details
- License is optional (defaults to empty string) to maintain backward compatibility
- License information flows from the frontend's paper metadata through the extraction request and is embedded in the final `PaperStructure` object
- The implementation follows the existing pattern for optional metadata fields like `is_draft` and `user_id`

https://claude.ai/code/session_0193QYN5zv1QKMEDe2f3kjmG