### PR TITLE
Add core/peripheral edge classification to causal graphs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -571,29 +571,30 @@ class NlToDslResponse(BaseModel):
     query_dsl_regex: str
     explanation: str
 
-
 _NL_TO_DSL_PROMPT = """\
 あなたは MetaWeave の構造検索アシスタントです。
 ユーザーが自然言語で述べた課題・疑問を、MetaWeave-SMILES DSL の正規表現パターンに変換してください。
 
 ## MetaWeave-SMILES DSL の書式
 - 変数: [略号:概念名:オントロジータイプ]  例: [a:Agent:Organization]
-- 因果辺: -[relation:polarity]->  例: -[cause:+]->
+- コア因果辺（太線）: ==[relation:polarity]==>  例: ==[cause:+]==>
 - オントロジータイプ: Agent, Resource, Event, Purpose, InstitutionalAgent, IntentionalMoment
 
 ## 出力ルール
 1. Qdrant の payload テキスト検索 (部分一致) に適した正規表現を生成する
 2. ワイルドカード (.*) を活用し、具体的なドメイン用語ではなく抽象的な構造パターンを捉える
-3. 複数のパターンが考えられる場合は、最も包括的な1つを選ぶ
-4. 出力は JSON 形式で返す: {"query_dsl_regex": "<正規表現>", "explanation": "<日本語での簡潔な説明>"}
+3. 異分野検索の精度を上げるため、原則として論文の主眼である「コア因果辺（==[...]=>）」をターゲットとした正規表現を生成する
+4. 複数のパターンが考えられる場合は、最も包括的な1つを選ぶ
+5. 出力は JSON 形式で返す: {"query_dsl_regex": "<正規表現>", "explanation": "<日本語での簡潔な説明>"}
 
 ## 例
 入力: "限られた資源を複数の主体が奪い合う問題"
-出力: {"query_dsl_regex": "\\\\[.*:Agent\\\\].*-\\\\[.*compete.*\\\\]->.*\\\\[.*:Resource\\\\]", "explanation": "複数のエージェントがリソースを巡って競合する構造パターン"}
+出力: {"query_dsl_regex": "\\\\[.*:Agent\\\\].*==\\\\[.*compete.*\\\\]==>.*\\\\[.*:Resource\\\\]", "explanation": "複数のエージェントがリソースを巡って競合するコア構造パターン"}
 
 入力: "技術革新が既存のビジネスモデルを破壊する現象"
-出力: {"query_dsl_regex": "\\\\[.*:Event\\\\].*-\\\\[.*destroy.*:-\\\\]->.*\\\\[.*:Resource\\\\]", "explanation": "イベント（技術革新）がリソース（ビジネスモデル）を負の方向に変化させる構造"}
+出力: {"query_dsl_regex": "\\\\[.*:Event\\\\].*==\\\\[.*destroy.*:-\\\\]==>.*\\\\[.*:Resource\\\\]", "explanation": "イベント（技術革新）がリソース（ビジネスモデル）を負の方向に変化させるコア構造"}
 """
+
 
 
 @app.post("/api/search/nl-to-dsl", response_model=NlToDslResponse)

--- a/backend/metaweave/extractor.py
+++ b/backend/metaweave/extractor.py
@@ -350,21 +350,33 @@ def _finalize_structure(state: _AnalysisState, paper_id: str, license: str = "")
         "=== MetaWeave-SMILES DSL Instructions ===\n"
         "You MUST encode all extracted causal relationships (CausalEdge) and variables "
         "into the MetaWeave-SMILES DSL and store the result in abstract_structure.smiles_dsl.\n\n"
-        "DSL syntax:\n"
-        "  [variableID:OntologyType:concreteValue] -[relationType:polarity]-> [targetVariableID:OntologyType:concreteValue]\n"
-        "Example:\n"
-        "  [a:Agent:Toyota] -[causes:+]-> [r:Resource:Profit]\n\n"
+        "=== Core vs. Peripheral Edge Classification ===\n"
+        "Each CausalEdge must be classified as either CORE or PERIPHERAL:\n"
+        "- CORE (is_core=true): Backbone mechanisms essential to the paper's main argument. "
+        "These represent the fundamental causal chain without which the paper's thesis collapses.\n"
+        "- PERIPHERAL (is_core=false): Supplementary, contextual, or domain-specific relationships "
+        "that provide supporting detail but are not essential to the core mechanism.\n\n"
+        "DSL syntax (IMPORTANT — different connectors for core vs. peripheral):\n"
+        "  Core edge:       [varID:OntologyType:value] ==[relationType:polarity]=> [targetVarID:OntologyType:value]\n"
+        "  Peripheral edge: [varID:OntologyType:value] -[relationType:polarity]-> [targetVarID:OntologyType:value]\n\n"
+        "Examples:\n"
+        "  Core:       [a:Agent:Toyota] ==[causes:+]=> [r:Resource:Profit]\n"
+        "  Peripheral: [e:Event:MarketShift] -[correlates:+]-> [r:Resource:Profit]\n\n"
         "Rules:\n"
         "1. Each variable must be assigned an OntologyType from the following: "
         "Agent, Resource, Event, Purpose-oriented group, Institutional Agent, Intentional Moment.\n"
         "2. Each CausalEdge must specify polarity (+ or -) in both the edge's polarity field "
         "and the DSL string.\n"
         "3. Each CausalEdge must specify ontology_level with the relevant ontology relation type.\n"
-        "4. If there is a cycle (loop) among variables, reuse the variable ID "
+        "4. Each CausalEdge must set is_core=true for core edges and is_core=false for peripheral edges. "
+        "Use ==[…]=> in the DSL for core edges and -[…]-> for peripheral edges.\n"
+        "5. If there is a cycle (loop) among variables, reuse the variable ID "
         "without repeating the full declaration (e.g., [a] instead of [a:Agent:Toyota]).\n"
-        "5. Chain multiple edges with spaces: "
-        "[a:Agent:X] -[causes:+]-> [r:Resource:Y] [r] -[inhibits:-]-> [a]\n"
-        "6. Classify all extraction targets strictly according to OntologyType.\n"
+        "6. Chain multiple edges with spaces: "
+        "[a:Agent:X] ==[causes:+]=> [r:Resource:Y] [r] -[inhibits:-]-> [a]\n"
+        "7. Classify all extraction targets strictly according to OntologyType.\n"
+        "8. Aim for roughly 30-50%% of edges to be core. If all edges seem equally important, "
+        "select only the most fundamental causal chain as core.\n"
     )
 
     resp = client.beta.chat.completions.parse(
@@ -724,15 +736,33 @@ def extract_abstraction_pattern(structure: PaperStructure) -> AbstractionPattern
     client = get_client()
     settings = get_settings()
 
+    # Core edges のみを優先して抽出データを構築
+    core_edges = [e for e in structure.abstract_structure.edges if e.is_core]
+    peripheral_edges = [e for e in structure.abstract_structure.edges if not e.is_core]
+
+    core_edges_desc = "\n".join(
+        f"  - {e.source} {e.relation}({e.polarity}) {e.target}" for e in core_edges
+    ) or "  (none)"
+    peripheral_edges_desc = "\n".join(
+        f"  - {e.source} {e.relation}({e.polarity}) {e.target}" for e in peripheral_edges
+    ) or "  (none)"
+
     prompt = (
         "あなたはメタ構造転写エンジンの一部です。\n"
         "以下の論文構造データから、具体的な事象を「変数（X, Y, Z等）」に置き換え、\n"
         "分野横断で適用可能な汎用的な「問題解決の型（Abstraction Pattern）」を抽出してください。\n\n"
+        "【重要：Core Edge 優先】\n"
+        "論文の因果グラフには Core（骨格メカニズム）と Peripheral（補足要素）の区別があります。\n"
+        "パターン抽出では Core edges を最優先で structural_rules に反映し、\n"
+        "Peripheral edges は補足情報として参考にしつつ、パターンの本質に含めないでください。\n\n"
+        f"--- Core Edges (骨格メカニズム) ---\n{core_edges_desc}\n\n"
+        f"--- Peripheral Edges (補足要素) ---\n{peripheral_edges_desc}\n\n"
         "【ルール】\n"
         "- name: パターンの簡潔な名称（英語、20語以内）\n"
         "- description: パターンの説明（具体的なドメイン用語は使わず、抽象変数で記述）\n"
         "- variables_template: パターン内で使われる抽象変数のリスト（例: [\"X\", \"Y\", \"Z\"]）\n"
-        "- structural_rules: 変数間の関係ルール（例: [\"X inhibits Y\", \"Y enables Z\"]）\n\n"
+        "- structural_rules: 変数間の関係ルール（例: [\"X inhibits Y\", \"Y enables Z\"]）。\n"
+        "  Core edges のみから structural_rules を構成してください。\n\n"
         f"--- 論文構造データ ---\n{structure.model_dump_json(indent=2)}\n\n"
         f'source_arxiv_id は "{structure.paper_id}" を設定してください。\n'
         "JSONスキーマに厳格に従って出力してください。"

--- a/backend/metaweave/schema.py
+++ b/backend/metaweave/schema.py
@@ -62,6 +62,10 @@ class CausalEdge(BaseModel):
     relation: str = Field(default="causes", description="Type of relation (causes, inhibits, correlates, ...)")
     polarity: str = Field(default="+", description="Causal polarity (+/-)")
     ontology_level: str = Field(default="", description="Ontology relation type (e.g., Intentional Moment)")
+    is_core: bool = Field(
+        default=True,
+        description="True for backbone/core mechanism edges, False for peripheral/supplementary edges",
+    )
 
 
 class AbstractStructure(BaseModel):

--- a/backend/tests/test_diff_merge.py
+++ b/backend/tests/test_diff_merge.py
@@ -354,3 +354,70 @@ class TestEvaluateAndMergeDiffBased:
         result = evaluate_and_merge_proposals(base, proposed)
 
         assert result.merged_structure.paper_id == "2401.00001"
+
+
+# ---------------------------------------------------------------------------
+# CausalEdge is_core field tests (Issue #45)
+# ---------------------------------------------------------------------------
+
+class TestCausalEdgeIsCore:
+    """CausalEdge の is_core フィールドに関するテスト。"""
+
+    def test_default_is_core_true(self):
+        """is_core のデフォルト値は True。"""
+        edge = CausalEdge(source="A", target="B")
+        assert edge.is_core is True
+
+    def test_is_core_false(self):
+        """is_core=False を明示指定できる。"""
+        edge = CausalEdge(source="A", target="B", is_core=False)
+        assert edge.is_core is False
+
+    def test_is_core_serialization(self):
+        """is_core が model_dump に含まれる。"""
+        edge = CausalEdge(source="A", target="B", relation="inhibits", polarity="-", is_core=False)
+        d = edge.model_dump()
+        assert "is_core" in d
+        assert d["is_core"] is False
+
+    def test_structure_with_mixed_core_edges(self):
+        """core と peripheral の混合エッジを含む PaperStructure を構築できる。"""
+        structure = _make_structure(
+            abstract_structure=AbstractStructure(
+                variables=["X", "Y", "Z"],
+                edges=[
+                    CausalEdge(source="X", target="Y", relation="causes", polarity="+", is_core=True),
+                    CausalEdge(source="Y", target="Z", relation="correlates", polarity="+", is_core=False),
+                ],
+                smiles_dsl="[x:Agent:X] ==[causes:+]=> [y:Resource:Y] [y] -[correlates:+]-> [z:Event:Z]",
+            )
+        )
+        core_edges = [e for e in structure.abstract_structure.edges if e.is_core]
+        peripheral_edges = [e for e in structure.abstract_structure.edges if not e.is_core]
+        assert len(core_edges) == 1
+        assert len(peripheral_edges) == 1
+        assert core_edges[0].source == "X"
+        assert peripheral_edges[0].source == "Y"
+
+    def test_is_core_change_detected_in_diff(self):
+        """is_core の変更が diff として検出される。"""
+        from metaweave.extractor import compute_structure_diff
+
+        base = _make_structure(
+            abstract_structure=AbstractStructure(
+                variables=["X", "Y"],
+                edges=[CausalEdge(source="X", target="Y", is_core=True)],
+                smiles_dsl="[x:Agent:X] ==[causes:+]=> [y:Resource:Y]",
+            )
+        )
+        proposed = _make_structure(
+            abstract_structure=AbstractStructure(
+                variables=["X", "Y"],
+                edges=[CausalEdge(source="X", target="Y", is_core=False)],
+                smiles_dsl="[x:Agent:X] -[causes:+]-> [y:Resource:Y]",
+            )
+        )
+        diffs = compute_structure_diff(base, proposed)
+        paths = {d.field_path for d in diffs}
+        assert "abstract_structure.edges" in paths
+        assert "abstract_structure.smiles_dsl" in paths

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -862,6 +862,73 @@ elif page == "Validation View":
                             "🔄 **解析処理中です。** 完了後に構造データが表示されます。"
                         )
 
+                    # ── Causal Graph Visualization (outside form) ──
+                    _cg_edges = s["abstract_structure"].get("edges", [])
+                    _cg_vars = s["abstract_structure"].get("variables", [])
+                    if _cg_edges:
+                        with st.expander("🔗 Causal Graph (Core = thick, Peripheral = thin)", expanded=False):
+                            # Build vis-network HTML
+                            _vis_nodes = []
+                            _vis_node_ids = set()
+                            for _e in _cg_edges:
+                                for _v in (_e.get("source", ""), _e.get("target", "")):
+                                    if _v and _v not in _vis_node_ids:
+                                        _vis_node_ids.add(_v)
+                                        _vis_nodes.append({"id": _v, "label": _v})
+                            # Also add variables not in edges
+                            for _v in _cg_vars:
+                                if _v and _v not in _vis_node_ids:
+                                    _vis_node_ids.add(_v)
+                                    _vis_nodes.append({"id": _v, "label": _v})
+
+                            _vis_edges = []
+                            for _idx, _e in enumerate(_cg_edges):
+                                _is_core = _e.get("is_core", True)
+                                _vis_edges.append({
+                                    "from": _e.get("source", ""),
+                                    "to": _e.get("target", ""),
+                                    "label": f"{_e.get('relation', '')} ({_e.get('polarity', '+')})",
+                                    "width": 4 if _is_core else 1,
+                                    "color": "#2196F3" if _is_core else "#BDBDBD",
+                                    "dashes": False if _is_core else True,
+                                    "arrows": "to",
+                                })
+
+                            import json as _json_cg
+                            _vis_html = f"""
+                            <html>
+                            <head>
+                            <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+                            <style>
+                                #causal-graph {{ width: 100%; height: 420px; border: 1px solid #ccc; }}
+                                .legend {{ font-family: sans-serif; font-size: 13px; margin-top: 6px; }}
+                                .legend span {{ display: inline-block; width: 40px; height: 4px; vertical-align: middle; margin-right: 6px; }}
+                            </style>
+                            </head>
+                            <body>
+                            <div id="causal-graph"></div>
+                            <div class="legend">
+                                <span style="background:#2196F3;height:4px;"></span> Core (backbone)
+                                &nbsp;&nbsp;
+                                <span style="background:#BDBDBD;height:2px;border-top:1px dashed #BDBDBD;"></span> Peripheral (supplementary)
+                            </div>
+                            <script>
+                                var nodes = new vis.DataSet({_json_cg.dumps(_vis_nodes)});
+                                var edges = new vis.DataSet({_json_cg.dumps(_vis_edges)});
+                                var container = document.getElementById('causal-graph');
+                                var data = {{ nodes: nodes, edges: edges }};
+                                var options = {{
+                                    physics: {{ stabilization: true }},
+                                    edges: {{ font: {{ size: 11 }}, smooth: {{ type: 'cubicBezier' }} }},
+                                    nodes: {{ shape: 'box', font: {{ size: 14 }}, margin: 8 }}
+                                }};
+                                new vis.Network(container, data, options);
+                            </script>
+                            </body>
+                            </html>
+                            """
+                            components.html(_vis_html, height=480)
+
                     with st.form(f"structure_form_{active_id}"):
                         tab_dsl, tab1, tab2, tab3 = st.tabs(
                             ["🧬 SMILES DSL", "Problem / Hypothesis", "Method / Constraints", "Raw Variables & Edges"]
@@ -869,6 +936,9 @@ elif page == "Validation View":
 
                         with tab_dsl:
                             st.markdown("#### Abstract Structure — SMILES DSL")
+                            st.caption(
+                                "Core edges: `==[rel:pol]=>` (thick) / Peripheral edges: `-[rel:pol]->` (thin)"
+                            )
                             smiles_dsl = st.text_area(
                                 "MetaWeave-SMILES DSL",
                                 value=s["abstract_structure"].get("smiles_dsl", ""),


### PR DESCRIPTION
## Summary
This PR introduces a distinction between core (backbone) and peripheral (supplementary) causal edges in paper structure analysis. Core edges represent essential mechanisms fundamental to a paper's thesis, while peripheral edges provide supporting context. This classification is now reflected throughout the extraction pipeline, visualization, and pattern abstraction.

## Key Changes

- **Schema Enhancement** (`schema.py`):
  - Added `is_core: bool` field to `CausalEdge` model (defaults to `True`)
  - Distinguishes backbone mechanisms from supplementary relationships

- **Extraction Instructions** (`extractor.py`):
  - Updated LLM prompt to explicitly classify edges as core or peripheral
  - Introduced DSL syntax distinction: `==[rel:pol]=>` for core edges, `-[rel:pol]->` for peripheral edges
  - Added guidance that ~30-50% of edges should be classified as core
  - Updated `extract_abstraction_pattern()` to prioritize core edges when building structural rules, using peripheral edges only as supporting context

- **Frontend Visualization** (`app.py`):
  - Added interactive causal graph visualization using vis-network library
  - Core edges rendered with thick blue lines; peripheral edges with thin dashed gray lines
  - Graph displays in an expandable section with legend distinguishing edge types
  - Added caption explaining DSL syntax for core vs. peripheral edges

- **Test Coverage** (`test_diff_merge.py`):
  - Added `TestCausalEdgeIsCore` test class with 5 tests covering:
    - Default `is_core=True` behavior
    - Explicit `is_core=False` assignment
    - Serialization of `is_core` field
    - Mixed core/peripheral edge structures
    - Diff detection of `is_core` changes

## Implementation Details

- The DSL syntax now uses different connectors to visually represent edge classification, making the distinction immediately apparent in the SMILES-like notation
- Pattern abstraction now filters to core edges only when building structural rules, preventing peripheral relationships from polluting the abstraction pattern
- The visualization provides immediate visual feedback on which relationships are considered fundamental vs. supplementary

https://claude.ai/code/session_01RpwTGv1pKUUFXbBew6KMxn