### PR TITLE
Fix review status enum usage and DSL syntax in tests

### DIFF
--- a/backend/tests/test_diff_merge.py
+++ b/backend/tests/test_diff_merge.py
@@ -25,6 +25,7 @@ from metaweave.schema import (
     Methodology,
     PaperStructure,
     ProblemStatement,
+    ReviewStatus,
 )
 
 # テスト用の Lazy import（extractor は OpenAI client を必要とするが、
@@ -134,7 +135,7 @@ class TestComputeStructureDiff:
 
         base = _make_structure()
         proposed = _make_structure()
-        proposed.review_status = "approved"
+        proposed.review_status = ReviewStatus.APPROVED
         diffs = compute_structure_diff(base, proposed)
         assert len(diffs) == 0
 
@@ -323,7 +324,7 @@ class TestEvaluateAndMergeDiffBased:
         mock_resp.choices = [MagicMock(message=MagicMock(content=llm_response))]
         mock_client.return_value.chat.completions.create.return_value = mock_resp
 
-        original_dsl = "(x:Agent:X) -[causes:+]-> (y:Resource:Y)"
+        original_dsl = "(x:Agent:X) -[CAUSES:causes:+]-> (y:Resource:Y)"
         base = _make_structure()
         proposed = _make_structure(title="New Title")
         result = evaluate_and_merge_proposals(base, proposed)


### PR DESCRIPTION
## Summary
Updated test cases to use proper enum types and corrected DSL syntax to match the expected format.

## Key Changes
- **Import ReviewStatus enum**: Added `ReviewStatus` to the imports from the models module to enable proper enum usage in tests
- **Use ReviewStatus enum**: Changed `proposed.review_status = "approved"` to `proposed.review_status = ReviewStatus.APPROVED` to use the proper enum type instead of a string literal
- **Fix DSL syntax**: Updated the original DSL string from `"(x:Agent:X) -[causes:+]-> (y:Resource:Y)"` to `"(x:Agent:X) -[CAUSES:causes:+]-> (y:Resource:Y)"` to match the expected DSL format with the relation type prefix

## Notable Details
These changes ensure that:
1. The test properly validates that `review_status` changes are excluded from diffs when using the correct enum type
2. The DSL test case uses the correct syntax format expected by the system

https://claude.ai/code/session_01ADwCJXiUCK1JxN2rRjbo27