### PR TITLE
Add Semantic Scholar citation counts to search results

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -46,6 +46,7 @@ from metaweave.batch import run_pattern_evaluation_task
 from metaweave.chat import generate_chat_response
 from metaweave.db import get_driver
 from metaweave.embedder import embed_and_store_pattern, search_fanns_hybrid
+from metaweave.citations import fetch_citation_counts
 from metaweave.harvester import PaperMeta, fetch_and_store, search_arxiv
 from metaweave.llm import generate_missing_link_suggestions, get_client, get_settings
 from metaweave.schema import (
@@ -113,6 +114,7 @@ class PaperMetaOut(BaseModel):
     published: str
     license: str
     commercial_flag: bool
+    citation_count: int = 0
 
 
 class FetchRequest(BaseModel):
@@ -125,6 +127,7 @@ class FetchRequest(BaseModel):
     published: str
     license: str = ""
     commercial_flag: bool = False
+    citation_count: int = 0
 
 
 class FetchResponse(BaseModel):
@@ -486,13 +489,26 @@ def healthz() -> dict:
 def search(
     query: str = Query(..., description="arXiv search query (e.g. cat:cs.AI)"),
     max_results: int = Query(default=20, ge=1, le=100),
+    sort_by: str = Query(default="newest", description="Sort order: 'newest' or 'most_cited'"),
 ) -> list[PaperMetaOut]:
-    """Search arXiv and return paper metadata with commercial-publisher flags."""
+    """Search arXiv and return paper metadata with commercial-publisher flags and citation counts."""
     try:
         results = search_arxiv(query, max_results=max_results)
     except Exception as exc:
         logger.exception("arXiv search failed")
         raise HTTPException(status_code=502, detail=f"arXiv search failed: {exc}") from exc
+
+    # Fetch citation counts from Semantic Scholar
+    arxiv_ids = [m.arxiv_id for m in results]
+    citation_map = fetch_citation_counts(arxiv_ids)
+
+    # Merge citation counts into results
+    for m in results:
+        m.citation_count = citation_map.get(m.arxiv_id, 0)
+
+    # Sort by citation count if requested
+    if sort_by == "most_cited":
+        results.sort(key=lambda m: m.citation_count, reverse=True)
 
     return [
         PaperMetaOut(
@@ -505,6 +521,7 @@ def search(
             published=m.published,
             license=m.license,
             commercial_flag=m.commercial_flag,
+            citation_count=m.citation_count,
         )
         for m in results
     ]

--- a/backend/metaweave/citations.py
+++ b/backend/metaweave/citations.py
@@ -1,0 +1,75 @@
+"""Semantic Scholar API integration for citation counts."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+SEMANTIC_SCHOLAR_BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
+SEMANTIC_SCHOLAR_PAPER_URL = "https://api.semanticscholar.org/graph/v1/paper"
+
+# Maximum papers per batch request (Semantic Scholar limit is 500)
+_BATCH_SIZE = 500
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
+)
+def _post_batch(arxiv_ids: list[str]) -> dict:
+    """POST to Semantic Scholar batch endpoint with retry logic.
+
+    Returns a dict mapping arXiv ID -> citation count.
+    """
+    paper_ids = [f"ArXiv:{aid}" for aid in arxiv_ids]
+    resp = requests.post(
+        SEMANTIC_SCHOLAR_BATCH_URL,
+        json={"ids": paper_ids},
+        params={"fields": "citationCount,externalIds"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    results: dict[str, int] = {}
+    for item in resp.json():
+        if item is None:
+            continue
+        ext_ids = item.get("externalIds") or {}
+        aid = ext_ids.get("ArXiv", "")
+        count = item.get("citationCount")
+        if aid and count is not None:
+            results[aid] = count
+    return results
+
+
+def fetch_citation_counts(arxiv_ids: list[str]) -> dict[str, int]:
+    """Fetch citation counts for a list of arXiv IDs from Semantic Scholar.
+
+    Returns a dict mapping arXiv ID -> citation count.
+    Papers not found in Semantic Scholar default to 0.
+    """
+    if not arxiv_ids:
+        return {}
+
+    result: dict[str, int] = {}
+
+    # Process in batches
+    for i in range(0, len(arxiv_ids), _BATCH_SIZE):
+        batch = arxiv_ids[i : i + _BATCH_SIZE]
+        try:
+            batch_result = _post_batch(batch)
+            result.update(batch_result)
+        except Exception:
+            logger.warning(
+                "Semantic Scholar batch request failed for %d papers; "
+                "falling back to citation_count=0",
+                len(batch),
+                exc_info=True,
+            )
+
+    return result

--- a/backend/metaweave/harvester.py
+++ b/backend/metaweave/harvester.py
@@ -42,6 +42,7 @@ class PaperMeta:
     published: str
     license: str = ""
     commercial_flag: bool = False
+    citation_count: int = 0
 
 
 def _extract_id(id_url: str) -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ neo4j>=5.0,<6
 PyJWT>=2.8,<3
 passlib>=1.7,<2
 bcrypt==3.2.2
+tenacity>=8.2,<10

--- a/backend/tests/test_citations.py
+++ b/backend/tests/test_citations.py
@@ -1,0 +1,83 @@
+"""Tests for the Semantic Scholar citation count integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metaweave.citations import fetch_citation_counts
+
+
+class TestFetchCitationCounts:
+    """Tests for fetch_citation_counts()."""
+
+    def test_empty_list_returns_empty_dict(self):
+        result = fetch_citation_counts([])
+        assert result == {}
+
+    @patch("metaweave.citations._post_batch")
+    def test_successful_batch_response(self, mock_post: MagicMock):
+        mock_post.return_value = {
+            "2301.00001": 42,
+            "2301.00002": 7,
+        }
+        result = fetch_citation_counts(["2301.00001", "2301.00002"])
+        assert result == {"2301.00001": 42, "2301.00002": 7}
+        mock_post.assert_called_once_with(["2301.00001", "2301.00002"])
+
+    @patch("metaweave.citations._post_batch")
+    def test_missing_paper_defaults_to_absent(self, mock_post: MagicMock):
+        """Papers not found in Semantic Scholar are simply absent from the result dict."""
+        mock_post.return_value = {"2301.00001": 10}
+        result = fetch_citation_counts(["2301.00001", "2301.00002"])
+        assert result == {"2301.00001": 10}
+        # The caller should use .get(id, 0) to default missing ones to 0.
+
+    @patch("metaweave.citations._post_batch")
+    def test_batch_failure_returns_empty(self, mock_post: MagicMock):
+        """If the API call fails after retries, gracefully return empty."""
+        mock_post.side_effect = Exception("API error")
+        result = fetch_citation_counts(["2301.00001"])
+        assert result == {}
+
+    @patch("metaweave.citations._post_batch")
+    def test_large_batch_split(self, mock_post: MagicMock):
+        """Lists > 500 papers should be split into multiple batches."""
+        ids = [f"2301.{i:05d}" for i in range(600)]
+        mock_post.return_value = {}
+        fetch_citation_counts(ids)
+        assert mock_post.call_count == 2
+        assert len(mock_post.call_args_list[0][0][0]) == 500
+        assert len(mock_post.call_args_list[1][0][0]) == 100
+
+
+class TestCitationMergeLogic:
+    """Tests for citation count merge and sort logic."""
+
+    @patch("metaweave.citations._post_batch")
+    def test_merge_and_sort_by_citation(self, mock_post: MagicMock):
+        """Simulate the merge + sort logic used in the search endpoint."""
+        mock_post.return_value = {"2301.00001": 5, "2301.00002": 100}
+        citation_map = fetch_citation_counts(["2301.00001", "2301.00002"])
+
+        # Simulate sorting
+        items = [
+            {"arxiv_id": "2301.00001", "count": citation_map.get("2301.00001", 0)},
+            {"arxiv_id": "2301.00002", "count": citation_map.get("2301.00002", 0)},
+        ]
+        items.sort(key=lambda m: m["count"], reverse=True)
+
+        assert items[0]["arxiv_id"] == "2301.00002"
+        assert items[0]["count"] == 100
+        assert items[1]["arxiv_id"] == "2301.00001"
+        assert items[1]["count"] == 5
+
+    @patch("metaweave.citations._post_batch")
+    def test_missing_papers_default_to_zero(self, mock_post: MagicMock):
+        """Papers not in Semantic Scholar should default to 0 via .get()."""
+        mock_post.return_value = {"2301.00001": 10}
+        citation_map = fetch_citation_counts(["2301.00001", "2301.00002"])
+
+        assert citation_map.get("2301.00001", 0) == 10
+        assert citation_map.get("2301.00002", 0) == 0

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -140,10 +140,10 @@ def _auth_headers() -> dict:
     return {"Authorization": f"Bearer {st.session_state.token}"}
 
 
-def api_search(query: str, max_results: int) -> list[dict]:
+def api_search(query: str, max_results: int, sort_by: str = "newest") -> list[dict]:
     resp = requests.get(
         f"{BACKEND_URL}/api/search",
-        params={"query": query, "max_results": max_results},
+        params={"query": query, "max_results": max_results, "sort_by": sort_by},
         headers=_auth_headers(),
         timeout=60,
     )
@@ -635,13 +635,21 @@ if page == "Harvester Dashboard":
 
     with st.form("search_form"):
         query = st.text_input("arXiv search query", value="cat:cs.AI")
-        max_results = st.slider("Max results", 5, 50, 10)
+        form_cols = st.columns([2, 1])
+        with form_cols[0]:
+            max_results = st.slider("Max results", 5, 50, 10)
+        with form_cols[1]:
+            sort_by = st.selectbox(
+                "Sort by",
+                options=["newest", "most_cited"],
+                format_func=lambda x: "Newest" if x == "newest" else "Most Cited",
+            )
         submitted = st.form_submit_button("Search")
 
     if submitted and query:
         with st.spinner("Querying arXiv via backend …"):
             try:
-                st.session_state.search_results = api_search(query, max_results)
+                st.session_state.search_results = api_search(query, max_results, sort_by)
             except Exception as exc:
                 st.error(f"Search failed: {exc}")
 
@@ -657,7 +665,11 @@ if page == "Harvester Dashboard":
                 categories = meta.get("categories", [])
 
                 with cols[0]:
-                    st.markdown(f"**{meta['title']}**")
+                    citation_count = meta.get("citation_count", 0)
+                    title_line = f"**{meta['title']}**"
+                    if citation_count > 0:
+                        title_line += f"  \u2003📈 Citations: {citation_count}"
+                    st.markdown(title_line)
                     st.caption(
                         f"Authors: {', '.join(authors[:3])}{'…' if len(authors) > 3 else ''}  \n"
                         f"Categories: {', '.join(categories)}  |  "


### PR DESCRIPTION
## Summary
Integrate Semantic Scholar API to fetch and display citation counts for papers in search results, with support for sorting by citation count.

## Key Changes
- **New citation integration module** (`backend/metaweave/citations.py`):
  - `fetch_citation_counts()` function to batch-fetch citation counts from Semantic Scholar API
  - `_post_batch()` helper with retry logic (3 attempts with exponential backoff) for resilience
  - Automatic batching for large paper lists (max 500 per request per API limits)
  - Graceful fallback to empty results on API failures

- **Backend API updates** (`backend/main.py`):
  - Added `citation_count` field to `PaperMetaOut` and `FetchRequest` schemas
  - Extended `/api/search` endpoint with `sort_by` parameter supporting "newest" (default) and "most_cited"
  - Integrated citation fetching into search workflow with result merging and optional sorting

- **Frontend enhancements** (`frontend/app.py`):
  - Added sort order selector in search form (Newest / Most Cited)
  - Display citation count badge next to paper titles when available
  - Pass sort preference to backend API

- **Data model updates** (`backend/metaweave/harvester.py`):
  - Added `citation_count` field to `PaperMeta` dataclass

- **Test coverage** (`backend/tests/test_citations.py`):
  - Comprehensive unit tests for citation fetching, batch splitting, error handling, and merge/sort logic

## Implementation Details
- Citation counts default to 0 for papers not found in Semantic Scholar
- Batch requests are split into chunks of 500 to respect API limits
- API failures are logged as warnings but don't block search results
- Uses `tenacity` library for robust retry handling with exponential backoff

https://claude.ai/code/session_01LPodJSawiBuQKY5uKpPP2d