### PR TITLE
Add data export endpoints for private backups and public DSL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,8 @@ POST /api/auth/register                 Register a new user (Neo4j User node, re
 POST /api/auth/login                    Authenticate and return a JWT.
 GET  /api/auth/me                       Return the current user's profile (requires Bearer token).
 GET  /api/patterns/{pattern_id}/suggestions  Missing link suggestions for a pattern.
+GET  /api/export/private/{user_id}     Export user's private data (drafts, chat history) as JSON.
+GET  /api/export/public/github         Export sanitized public DSL data for GitHub (Gateway-filtered).
 GET  /healthz                           Health check.
 """
 
@@ -50,11 +52,15 @@ from metaweave.harvester import PaperMeta, fetch_and_store, search_arxiv
 from metaweave.llm import generate_missing_link_suggestions, get_client, get_settings
 from metaweave.schema import (
     AbstractionPattern,
+    ChatHistoryEntry,
+    DraftEntry,
     FieldSuggestion,
     MetaIssueCategory,
     MissingLinkSuggestion,
     PaperStructure,
     PatternMatch,
+    PrivateBackupExport,
+    PublicDSLExport,
     StructureProposal,
     SystemMetaProposal,
 )
@@ -1734,3 +1740,151 @@ def get_pattern_suggestions(
         suggestions=[SuggestionOut(**s) for s in suggestions],
         cached=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# Export endpoints (3 Zones + Gateway)
+# ---------------------------------------------------------------------------
+
+
+class PrivateExportResponse(BaseModel):
+    """Response wrapper for GET /api/export/private/{user_id}."""
+
+    export: PrivateBackupExport
+
+
+class PublicExportResponse(BaseModel):
+    """Response for GET /api/export/public/github."""
+
+    records: list[PublicDSLExport]
+    dropped_count: int = 0
+
+
+@app.get("/api/export/private/{user_id}", response_model=PrivateExportResponse)
+def export_private(
+    user_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> PrivateExportResponse:
+    """Private Zone バックアップ: ユーザー個人のドラフトとチャット履歴をフルエクスポートする。"""
+    if user_id != current_user["id"]:
+        raise HTTPException(status_code=403, detail="You can only export your own data")
+
+    driver = get_driver()
+
+    # ── 1. Collect all drafts ────────────────────────────────────────────
+    drafts: list[DraftEntry] = []
+    with driver.session() as session:
+        records = session.run(
+            """
+            MATCH (u:User {id: $uid})-[:HAS_DRAFT]->(d:Draft)
+            RETURN d.arxiv_id AS arxiv_id, d.structure AS structure
+            """,
+            uid=user_id,
+        ).data()
+    for rec in records:
+        aid = rec.get("arxiv_id", "")
+        raw = rec.get("structure", "")
+        if not raw:
+            continue
+        try:
+            ps = PaperStructure.model_validate_json(raw)
+            drafts.append(DraftEntry(arxiv_id=aid, structure=ps))
+        except Exception:
+            logger.warning("Skipping unparseable draft for arxiv_id=%s", aid)
+
+    # ── 2. Collect all chat histories ────────────────────────────────────
+    chat_histories: list[ChatHistoryEntry] = []
+    with driver.session() as session:
+        records = session.run(
+            """
+            MATCH (u:User {id: $uid})-[r:CHATTED_ABOUT]->(p:Paper)
+            RETURN p.arxiv_id AS arxiv_id, r.history AS history
+            """,
+            uid=user_id,
+        ).data()
+    for rec in records:
+        aid = rec.get("arxiv_id", "")
+        raw_hist = rec.get("history", "")
+        if not raw_hist:
+            continue
+        try:
+            messages = json.loads(raw_hist) if isinstance(raw_hist, str) else raw_hist
+        except Exception:
+            messages = []
+        chat_histories.append(ChatHistoryEntry(arxiv_id=aid, messages=messages))
+
+    export = PrivateBackupExport(
+        user_id=user_id,
+        exported_at=datetime.datetime.utcnow().isoformat(),
+        drafts=drafts,
+        chat_histories=chat_histories,
+    )
+    return PrivateExportResponse(export=export)
+
+
+import re as _re
+
+_LICENSE_CONTAMINATION_RE = _re.compile(r"\b(NC|ND|NoDerivatives|NonCommercial)\b", _re.IGNORECASE)
+
+
+@app.get("/api/export/public/github", response_model=PublicExportResponse)
+def export_public_github(
+    current_user: dict = Depends(_get_current_user),
+) -> PublicExportResponse:
+    """Public Zone エクスポート: Gateway を通過した DSL のみを返却する。
+
+    ライセンス汚染（NC / ND）を含むレコードは完全に除外（Drop）する。
+    """
+    sm = StorageManager()
+    bucket = "extracted-structures"
+
+    # ── 1. List all extracted structures from MinIO ───────────────────────
+    try:
+        objects = sm.client.list_objects(bucket, recursive=True)
+        object_names = [obj.object_name for obj in objects]
+    except Exception:
+        logger.warning("Failed to list objects in bucket=%s", bucket)
+        object_names = []
+
+    records: list[PublicDSLExport] = []
+    dropped = 0
+
+    for obj_name in object_names:
+        # ── 2. Load and parse PaperStructure ─────────────────────────────
+        try:
+            resp = sm.client.get_object(bucket, obj_name)
+            raw = resp.read()
+            resp.close()
+            resp.release_conn()
+            ps = PaperStructure.model_validate_json(raw)
+        except Exception:
+            logger.warning("Skipping unparseable object %s", obj_name)
+            continue
+
+        # ── 3. Gateway: drop license-contaminated records ────────────────
+        if _LICENSE_CONTAMINATION_RE.search(ps.license):
+            dropped += 1
+            continue
+
+        # ── 4. Build context_summary from problem/hypothesis (de-expressed) ─
+        summary_parts = []
+        if ps.problem.problem:
+            summary_parts.append(ps.problem.problem)
+        if ps.hypothesis.statement:
+            summary_parts.append(ps.hypothesis.statement)
+        context_summary = " ".join(summary_parts)
+
+        # Derive arXiv URL from paper_id
+        source_url = f"https://arxiv.org/abs/{ps.paper_id}" if ps.paper_id else ""
+
+        records.append(
+            PublicDSLExport(
+                title=ps.title,
+                source_url=source_url,
+                original_license=ps.license,
+                metaweave_smiles=ps.abstract_structure.smiles_dsl,
+                context_summary=context_summary,
+            )
+        )
+
+    return PublicExportResponse(records=records, dropped_count=dropped)

--- a/backend/metaweave/schema.py
+++ b/backend/metaweave/schema.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class OntologyType(str, Enum):
@@ -289,3 +289,72 @@ class MissingLinkSuggestion(BaseModel):
         default_factory=list,
         description="List of field-specific search suggestions",
     )
+
+
+# ---------------------------------------------------------------------------
+# Export schemas (3 Zones + Gateway)
+# ---------------------------------------------------------------------------
+
+
+class DraftEntry(BaseModel):
+    """A single draft entry for private backup export."""
+
+    arxiv_id: str = Field(description="arXiv paper identifier")
+    structure: PaperStructure = Field(description="Draft PaperStructure")
+
+
+class ChatHistoryEntry(BaseModel):
+    """A single chat history entry for private backup export."""
+
+    arxiv_id: str = Field(description="arXiv paper identifier")
+    messages: list[dict] = Field(default_factory=list, description="Chat messages")
+
+
+class PrivateBackupExport(BaseModel):
+    """Private Zone のフルバックアップスキーマ。
+
+    ユーザー個人の生データ（ドラフト、チャット履歴、抽出途中のノード等）を
+    すべて保持する。文字数制限なし。外部共有は厳禁。
+    """
+
+    user_id: str = Field(description="Exporting user's identifier")
+    exported_at: str = Field(description="ISO 8601 timestamp of export")
+    drafts: list[DraftEntry] = Field(default_factory=list, description="All user drafts")
+    chat_histories: list[ChatHistoryEntry] = Field(
+        default_factory=list, description="All user chat histories"
+    )
+
+
+class PublicDSLExport(BaseModel):
+    """Public Zone / GitHub 公開用の厳格なエクスポートスキーマ。
+
+    Gateway を通過し、著者の「表現」を完全に除去した純粋な DSL のみを保持する。
+    ライセンス汚染（CC BY-NC, ND 等）のレコードは事前に除外済みであること。
+    """
+
+    title: str = Field(description="Paper title")
+    authors: list[str] = Field(default_factory=list, description="Author names")
+    source_url: str = Field(default="", description="Original paper URL")
+    doi: str = Field(default="", description="Digital Object Identifier")
+    original_license: str = Field(description="License of the original paper")
+    metaweave_smiles: str = Field(description="MetaWeave-SMILES DSL string")
+    is_derived_data: bool = Field(
+        default=True,
+        description="Flag indicating this is derived/extracted data, not original content",
+    )
+    disclaimer_implementation: str = Field(
+        default="本データは論文の論理構造を抽出したものであり、記述された技術の実施（商業利用等）に関する特許等の実施権を保証するものではありません。",
+        description="Patent/implementation rights disclaimer",
+    )
+    context_summary: str = Field(
+        default="",
+        description="200文字以内の事実の概要（脱表現化済み）",
+    )
+
+    @field_validator("context_summary")
+    @classmethod
+    def truncate_context_summary(cls, v: str) -> str:
+        """Enforce the 200-character hard limit for de-expression compliance."""
+        if len(v) > 200:
+            return v[:199] + "…"
+        return v

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -424,6 +424,28 @@ def api_get_missing_link_suggestions(pattern_id: str, refresh: bool = False) -> 
     return resp.json()
 
 
+def api_export_private(user_id: str) -> dict:
+    """GET /api/export/private/{user_id} — download private backup."""
+    resp = requests.get(
+        f"{BACKEND_URL}/api/export/private/{user_id}",
+        headers=_auth_headers(),
+        timeout=120,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_export_public() -> dict:
+    """GET /api/export/public/github — download sanitized public DSL export."""
+    resp = requests.get(
+        f"{BACKEND_URL}/api/export/public/github",
+        headers=_auth_headers(),
+        timeout=120,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 def _auth_post(path: str, payload: dict) -> dict:
     """Helper: POST to an auth endpoint and return the response JSON dict."""
     resp = requests.post(f"{BACKEND_URL}{path}", json=payload, timeout=15)
@@ -571,6 +593,53 @@ with st.sidebar:
     st.markdown("## MetaWeave v1")
     st.caption(f"👤 {st.session_state.username}")
     page = st.radio("Navigation", ["Harvester Dashboard", "Validation View", "Pattern Library", "Cross-Domain Search", "🛠️ Meta Issues"])
+
+    # ── Data Management (Export) section ─────────────────────────────────
+    st.divider()
+    st.markdown("### 📦 データ管理")
+
+    # Private backup button
+    if st.button("🔒 私有地データのバックアップ (Private)", key="btn_export_private", use_container_width=True):
+        try:
+            _priv_data = api_export_private(st.session_state.user_id)
+            _priv_json = json.dumps(_priv_data, ensure_ascii=False, indent=2)
+            st.session_state["_private_export_json"] = _priv_json
+        except Exception as _e:
+            st.error(f"バックアップ取得に失敗しました: {_e}")
+
+    if st.session_state.get("_private_export_json"):
+        st.download_button(
+            label="⬇️ Private バックアップをダウンロード",
+            data=st.session_state["_private_export_json"],
+            file_name="metaweave_private_backup.json",
+            mime="application/json",
+            key="dl_private_export",
+            use_container_width=True,
+        )
+
+    # Public export button
+    if st.button("🌍 GitHub公開用シードのダウンロード (Public)", key="btn_export_public", use_container_width=True):
+        try:
+            _pub_data = api_export_public()
+            _pub_json = json.dumps(_pub_data, ensure_ascii=False, indent=2)
+            st.session_state["_public_export_json"] = _pub_json
+            _dropped = _pub_data.get("dropped_count", 0)
+            if _dropped:
+                st.info(f"ライセンス汚染により {_dropped} 件のレコードを除外しました。")
+        except Exception as _e:
+            st.error(f"Public エクスポート取得に失敗しました: {_e}")
+
+    if st.session_state.get("_public_export_json"):
+        st.download_button(
+            label="⬇️ Public DSL データをダウンロード",
+            data=st.session_state["_public_export_json"],
+            file_name="metaweave_public_dsl.json",
+            mime="application/json",
+            key="dl_public_export",
+            use_container_width=True,
+        )
+
+    st.caption("※ Public データは Gateway を通過済みの DSL のみを含みます。OSS 貢献者・管理者向けです。")
 
     if page == "Validation View":
         st.divider()


### PR DESCRIPTION
## Summary
This PR introduces two new export endpoints that enable users to download their data in structured formats, with strict separation between private user data and public, sanitized DSL exports suitable for open-source contribution.

## Key Changes

### Backend (`backend/main.py`)
- **New endpoint `GET /api/export/private/{user_id}`**: Exports user's private data including all drafts and chat histories as a complete backup. Includes authorization check to ensure users can only export their own data.
- **New endpoint `GET /api/export/public/github`**: Exports sanitized public DSL data filtered through a "Gateway" that removes license-contaminated records (CC BY-NC, ND, etc.). Includes de-expression of author content and derives context summaries from problem/hypothesis statements.
- Added response models `PrivateExportResponse` and `PublicExportResponse` for type safety
- Implemented license contamination detection using regex pattern matching for NC/ND indicators
- Integrated with MinIO storage to retrieve extracted structures from the `extracted-structures` bucket

### Schema (`backend/metaweave/schema.py`)
- **New `DraftEntry`**: Represents a single draft with arxiv_id and PaperStructure
- **New `ChatHistoryEntry`**: Represents chat history for a paper with messages list
- **New `PrivateBackupExport`**: Full backup schema for private zone containing user_id, export timestamp, all drafts, and chat histories
- **New `PublicDSLExport`**: Strict export schema for public/GitHub use with fields for title, source URL, license, MetaWeave-SMILES DSL, and de-expressed context summary (max 200 chars with validator)
- Added `field_validator` import for context summary truncation enforcement

### Frontend (`frontend/app.py`)
- **New `api_export_private()`**: Client function to fetch private backup data
- **New `api_export_public()`**: Client function to fetch public DSL export
- Added "📦 データ管理" (Data Management) section in the sidebar with:
  - Private backup button with download capability
  - Public export button with license contamination warning display
  - Appropriate Japanese labels and descriptions for both export types

## Notable Implementation Details
- Private exports include full, unfiltered user data with no character limits
- Public exports enforce strict filtering: license-contaminated records are completely dropped (not just flagged)
- Context summaries in public exports are de-expressed (derived from problem/hypothesis, not author text) and hard-limited to 200 characters
- Both endpoints require authentication via Bearer token
- Frontend provides user-friendly download buttons with session state management for export data
- Includes proper error handling and logging for unparseable records

https://claude.ai/code/session_01SifG1vjuFUcuaijETGtFSv