### PR TITLE
Add PDF upload functionality for local file processing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ Endpoints
 GET  /api/search                        Search arXiv for papers.
 POST /api/search/structure              FANNS hybrid search (DSL regex + vector similarity).
 POST /api/fetch                         Download a paper PDF and store it in MinIO.
+POST /api/upload-pdf                    Upload a local PDF file and store it in MinIO.
 POST /api/extract                       Submit async background extraction job.
 GET  /api/extract-status/{arxiv_id}     Poll extraction job status (pending/processing/completed/failed).
 GET  /api/extract-result/{arxiv_id}     Fetch a previously extracted paper structure from MinIO.
@@ -37,7 +38,7 @@ import uuid
 from functools import lru_cache
 
 import jwt
-from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query
+from fastapi import BackgroundTasks, Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from passlib.context import CryptContext
@@ -49,7 +50,7 @@ from metaweave.chat import generate_chat_response
 from metaweave.db import create_system_meta_proposal, get_driver
 from metaweave.isom import serialize_isom, write_isom_file, write_batch_isom
 from metaweave.embedder import embed_and_store_pattern, search_fanns_hybrid
-from metaweave.harvester import PaperMeta, fetch_and_store, search_arxiv
+from metaweave.harvester import PaperMeta, fetch_and_store, search_arxiv, store_uploaded_pdf
 from metaweave.llm import generate_missing_link_suggestions, get_client, get_settings
 from metaweave.schema import (
     AbstractionPattern,
@@ -731,6 +732,31 @@ def fetch(body: FetchRequest) -> FetchResponse:
         raise HTTPException(status_code=502, detail=f"Fetch failed: {exc}") from exc
 
     return FetchResponse(object_name=object_name)
+
+
+class UploadPdfResponse(BaseModel):
+    paper_id: str
+    object_name: str
+
+
+@app.post("/api/upload-pdf", response_model=UploadPdfResponse)
+async def upload_pdf(
+    file: UploadFile = File(...),
+    source_url: str = Form(""),
+    license: str = Form(""),
+) -> UploadPdfResponse:
+    """Upload a local PDF file and store it in MinIO."""
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Only PDF files are accepted.")
+    pdf_data = await file.read()
+    if len(pdf_data) == 0:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty.")
+    try:
+        paper_id, object_name = store_uploaded_pdf(pdf_data, file.filename, _storage())
+    except Exception as exc:
+        logger.exception("PDF upload/store failed")
+        raise HTTPException(status_code=502, detail=f"Upload failed: {exc}") from exc
+    return UploadPdfResponse(paper_id=paper_id, object_name=object_name)
 
 
 @app.post("/api/extract", response_model=ExtractAccepted)

--- a/backend/metaweave/extractor.py
+++ b/backend/metaweave/extractor.py
@@ -288,6 +288,15 @@ def _generate_hypothesis(first_chunk: str, paper_id: str) -> dict[str, Any]:
     return result
 
 
+def _to_str(item: object) -> str:
+    """Coerce an item to a string — handles dicts returned by the LLM."""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return json.dumps(item, ensure_ascii=False)
+    return str(item)
+
+
 def _refine_with_chunk(state: _AnalysisState, chunk: str, chunk_idx: int) -> None:
     """チャンクを読み込んで分析状態をインプレースで更新する。"""
     client = get_client()
@@ -297,7 +306,7 @@ def _refine_with_chunk(state: _AnalysisState, chunk: str, chunk_idx: int) -> Non
         f"Problem: {state.draft.get('problem', '')[:200]}\n"
         f"Hypothesis: {state.draft.get('hypothesis', '')[:200]}"
     )
-    confirmed_str = "; ".join(state.confirmed[-5:]) if state.confirmed else "none"
+    confirmed_str = "; ".join(_to_str(c) for c in state.confirmed[-5:]) if state.confirmed else "none"
 
     prompt = (
         f"[Chunk {chunk_idx}]\n"
@@ -341,8 +350,8 @@ def _finalize_structure(state: _AnalysisState, paper_id: str, license: str = "")
     client = get_client()
     settings = get_settings()
 
-    def _bullets(items: list[str], limit: int = 8) -> str:
-        return "\n".join(f"- {x}" for x in items[:limit]) or "none"
+    def _bullets(items: list, limit: int = 8) -> str:
+        return "\n".join(f"- {_to_str(x)}" for x in items[:limit]) or "none"
 
     state_str = (
         f"Confirmed findings:\n{_bullets(state.confirmed)}\n\n"

--- a/backend/metaweave/harvester.py
+++ b/backend/metaweave/harvester.py
@@ -137,3 +137,20 @@ def fetch_and_store(meta: PaperMeta, storage: StorageManager) -> str:
 
     storage.upload_pdf("raw-papers", object_name, resp.content)
     return object_name
+
+
+def store_uploaded_pdf(
+    pdf_data: bytes,
+    filename: str,
+    storage: StorageManager,
+) -> tuple[str, str]:
+    """Store a user-uploaded PDF in MinIO.
+
+    Returns (paper_id, object_name).
+    """
+    safe_name = re.sub(r"[^\w.\-]", "_", filename.rsplit(".", 1)[0])
+    paper_id = f"upload_{safe_name}"
+    object_name = f"uploads/{paper_id}.pdf"
+
+    storage.upload_pdf("raw-papers", object_name, pdf_data)
+    return paper_id, object_name

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110,<1
 uvicorn[standard]>=0.29,<1
+python-multipart>=0.0.7,<1
 minio>=7.2,<8
 pydantic>=2.5,<3
 requests>=2.31,<3

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -167,6 +167,19 @@ def api_fetch(paper: dict) -> str:
     return resp.json()["object_name"]
 
 
+def api_upload_pdf(file_data: bytes, filename: str, source_url: str = "", license: str = "") -> dict:
+    """POST /api/upload-pdf — upload a local PDF file. Returns {paper_id, object_name}."""
+    resp = requests.post(
+        f"{BACKEND_URL}/api/upload-pdf",
+        files={"file": (filename, file_data, "application/pdf")},
+        data={"source_url": source_url, "license": license},
+        headers=_auth_headers(),
+        timeout=120,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 def api_presigned_url(object_name: str) -> str:
     resp = requests.get(
         f"{BACKEND_URL}/api/presigned-url",
@@ -597,6 +610,56 @@ with st.sidebar:
     st.markdown("## MetaWeave v1")
     st.caption(f"👤 {st.session_state.username}")
     page = st.radio("Navigation", ["Harvester Dashboard", "Validation View", "Pattern Library", "Cross-Domain Search", "🛠️ Meta Issues"])
+
+    # ── PDF Upload section ─────────────────────────────────────────────
+    st.divider()
+    st.markdown("### 📄 PDF アップロード")
+    _uploaded_file = st.file_uploader(
+        "PDFファイルを選択",
+        type=["pdf"],
+        key="pdf_uploader",
+        label_visibility="collapsed",
+    )
+    _upload_source_url = st.text_input(
+        "入手元 URL（任意）",
+        placeholder="https://example.com/paper.pdf",
+        key="upload_source_url",
+    )
+    _upload_license = st.text_input(
+        "ライセンス（任意）",
+        placeholder="CC-BY-4.0 など",
+        key="upload_license",
+    )
+    if st.button("📤 アップロード & 解析開始", key="btn_upload_pdf", use_container_width=True, disabled=_uploaded_file is None):
+        if _uploaded_file is not None:
+            try:
+                with st.spinner("アップロード中…"):
+                    _pdf_bytes = _uploaded_file.read()
+                    _upload_resp = api_upload_pdf(
+                        _pdf_bytes,
+                        _uploaded_file.name,
+                        source_url=_upload_source_url,
+                        license=_upload_license,
+                    )
+                    _up_paper_id = _upload_resp["paper_id"]
+                    _up_object_name = _upload_resp["object_name"]
+                    st.session_state.stored_papers[_up_paper_id] = _up_object_name
+                    _up_title = _uploaded_file.name.rsplit(".", 1)[0]
+                    st.session_state.paper_metadata[_up_paper_id] = {
+                        "title": _up_title,
+                        "source_url": _upload_source_url,
+                        "license": _upload_license,
+                    }
+                # 非同期抽出ジョブをキュー登録
+                api_extract(_up_object_name, _up_paper_id, license=_upload_license)
+                st.session_state.processing_papers[_up_paper_id] = {
+                    "title": _up_title,
+                    "object_name": _up_object_name,
+                }
+                st.toast(f"⏳ 「{_up_title}」 の解析を開始しました")
+                st.rerun()
+            except Exception as _e:
+                st.error(f"アップロードに失敗しました: {_e}")
 
     # ── Data Management (Export) section ─────────────────────────────────
     st.divider()


### PR DESCRIPTION
## Summary
This PR adds the ability for users to upload local PDF files directly through the frontend, bypassing the need to fetch papers from arXiv. The uploaded PDFs are stored in MinIO and processed through the same extraction pipeline as fetched papers.

## Key Changes

**Frontend (frontend/app.py)**
- Added `api_upload_pdf()` function to POST PDF files to the backend with optional source URL and license metadata
- Added a new "📄 PDF アップロード" (PDF Upload) section in the sidebar with:
  - File uploader widget (PDF files only)
  - Optional source URL input field
  - Optional license input field
  - Upload button that triggers async extraction
- Integrated uploaded papers into the existing `stored_papers` and `paper_metadata` session state
- Queues extraction jobs and displays toast notification on successful upload

**Backend (backend/main.py)**
- Added `POST /api/upload-pdf` endpoint that accepts multipart form data with:
  - PDF file upload
  - Optional `source_url` and `license` form fields
- Validates that uploaded file is a PDF and non-empty
- Returns `{paper_id, object_name}` response
- Proper error handling with appropriate HTTP status codes

**Backend (backend/metaweave/harvester.py)**
- Added `store_uploaded_pdf()` function that:
  - Sanitizes the filename to create a safe paper ID
  - Stores PDF data in MinIO under `uploads/` prefix
  - Returns tuple of `(paper_id, object_name)` for downstream processing

## Implementation Details
- Uploaded PDFs are identified with `upload_` prefix in their paper IDs to distinguish them from arXiv-fetched papers
- The same extraction pipeline (`api_extract()`) is used for both fetched and uploaded PDFs
- User-provided metadata (source URL, license) is stored in session state for reference
- File validation occurs on both frontend (type restriction) and backend (extension and size checks)
- 120-second timeout for upload requests to handle larger files

https://claude.ai/code/session_01Fybb9W9bWcnGD4qLsdjEVZ